### PR TITLE
Update: `formatDate` funciton to use indian locale.

### DIFF
--- a/components/transactions/TransactionDetail.tsx
+++ b/components/transactions/TransactionDetail.tsx
@@ -7,7 +7,7 @@ export default function TransactionDetail({
   transaction: transactionSchemaType;
 }) {
   const isExpense = transaction.isExpense;
-  const transactionDate = formatDate(transaction.date);
+  const transactionDate = formatDate(transaction.date, undefined, true);
   const formattedAmount = formatCurrency(transaction.amount);
 
   return (

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,7 +1,9 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-const LOCALE = "en-IN";
+//  TODO: Localize these variables in future
+export const LOCALE = "en-IN" as const;
+export const TIMEZONE = "Asia/Kolkata" as const;
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -26,13 +28,17 @@ export function formatCurrency(amount: number) {
   return formattedCurrency;
 }
 
-export function formatDate(date: Date | string) {
-  const formattedDate = new Date(date).toLocaleDateString(LOCALE, {
-    month: "short",
+export function formatDate(
+  date: Date | string,
+  monthLength: "long" | "short" = "short",
+  showYear: boolean = false,
+) {
+  return new Intl.DateTimeFormat(LOCALE, {
+    timeZone: TIMEZONE,
     day: "numeric",
-  });
-
-  return formattedDate;
+    month: monthLength,
+    ...(showYear && { year: "numeric" }), // Include 'year' only if showYear is true
+  }).format(new Date(date));
 }
 
 export function toNormalCase(str: string): string {


### PR DESCRIPTION
#### Description
This pull request updates the `formatDate` function to utilize the Indian locale. Currently, the locale and timezone are hard-coded to `India` and `Asia/Kolkata`. This change is a step towards localizing the application, which we plan to address comprehensively in a future update.

#### Related Issue
This commit addresses issue #32 by improving date formatting to align with Indian standards.

#### Changes Made
- Updated `formatDate` function to use `locale` set to `en-IN` and `timezone` set to `Asia/Kolkata`.

#### Note
- The hardcoded values for `locale` and `timezone` will be revisited when we implement full localization across the app.