### PR TITLE
Fix: Infinite scroll trigger leaving viewport, stopping data fetching

### DIFF
--- a/components/transactions/InfiniteTransactionList.tsx
+++ b/components/transactions/InfiniteTransactionList.tsx
@@ -5,7 +5,7 @@ import { useInView } from "react-intersection-observer";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { fetchInfiniteTransactions } from "@/actions/handleCachedTransaction";
 import { TRANSACTION_PER_PAGE_FETCH_LIMIT } from "@/lib/defaultValues";
-import InfiniteTransactionWrapper from "./InfiniteTransactionSkeleton";
+import { InfiniteTransactionSkeletonWrapper } from "./InfiniteTransactionSkeleton";
 import TransactionItem from "@/components/transactions/TransactionItem";
 import EndOfTransaction from "@/components/transactions/EndOfTransaction";
 
@@ -27,23 +27,26 @@ export default function InfiniteTransactionList() {
   }, [inView, fetchNextPage]);
 
   return status === "pending" ? (
-    <InfiniteTransactionWrapper />
+    <InfiniteTransactionSkeletonWrapper />
   ) : status === "error" ? (
     <p>{error.message}</p>
   ) : (
-    <div className="space-y-1">
-      {data.pages.map((page, idx) => (
-        <Fragment key={idx}>
-          {page.data.map((transaction) => (
-            <TransactionItem key={transaction.id} transaction={transaction} />
-          ))}
-        </Fragment>
-      ))}
+    <>
+      <section className="space-y-1">
+        {data.pages.map((page, idx) => (
+          <Fragment key={idx}>
+            {page.data.map((transaction) => (
+              <TransactionItem key={transaction.id} transaction={transaction} />
+            ))}
+          </Fragment>
+        ))}
+      </section>
 
-      {/* TODO: don't always render 12 skeletons, canculate the number. */}
-      <div ref={ref}>
-        {hasNextPage ? <InfiniteTransactionWrapper /> : <EndOfTransaction />}
-      </div>
-    </div>
+      {hasNextPage ? (
+        <InfiniteTransactionSkeletonWrapper ref={ref} />
+      ) : (
+        <EndOfTransaction />
+      )}
+    </>
   );
 }

--- a/components/transactions/InfiniteTransactionSkeleton.tsx
+++ b/components/transactions/InfiniteTransactionSkeleton.tsx
@@ -1,17 +1,29 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import { TRANSACTION_PER_PAGE_FETCH_LIMIT } from "@/lib/defaultValues";
+import { forwardRef, DetailedHTMLProps, HTMLAttributes } from "react";
 
-export default function InfiniteTransactionWrapper() {
-  return (
-    <div className="space-y-1">
-      {Array.from({ length: TRANSACTION_PER_PAGE_FETCH_LIMIT }).map(
-        (_, idx) => (
-          <TransactionSkeleton key={idx} />
-        ),
-      )}
-    </div>
-  );
-}
+type Props = {} & Omit<
+  DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>,
+  "children"
+>;
+
+//  TODO: don't always render 12 skeletons, canculate the number. */
+export const InfiniteTransactionSkeletonWrapper = forwardRef<
+  HTMLDivElement,
+  Props
+>((props, ref) => (
+  <section
+    ref={ref}
+    className="transactions-infinite-scroll__trigger transaction-skeleton__wrapper space-y-1"
+    {...props}
+  >
+    {Array.from({ length: TRANSACTION_PER_PAGE_FETCH_LIMIT }).map((_, idx) => (
+      <TransactionSkeleton key={idx} />
+    ))}
+  </section>
+));
+InfiniteTransactionSkeletonWrapper.displayName =
+  "InfiniteTransactionSkeletonWrapper";
 
 export function TransactionSkeleton() {
   return <Skeleton className="h-[4.5rem] w-full rounded-md" />;


### PR DESCRIPTION
### Description:
This PR addresses a bug where the infinite scroll trigger would exit the viewport, causing data fetching to stop prematurely when users scrolled too far on the all-transaction page. The fix ensures that data fetching continues smoothly by using the skeleton loader as the new scroll trigger.

#### Key Changes:
- Replaced the previous infinite scroll trigger with the skeleton loader.
- The skeleton loader now acts as the trigger for fetching more data, ensuring it stays within the viewport and prevents data fetching from stopping unexpectedly.

---

### Why is this needed?
Previously, when users scrolled too far on the all-transaction page, the scroll trigger would leave the viewport, causing the infinite scroll to stop fetching data. This resulted in users not being able to view their full transaction history. By using the skeleton loader as the new trigger, the issue is resolved, and fetching will continue until all data is loaded.