### PR TITLE
Fix: Stale Offset Causing Transaction Fetching to Stop on All-Transactions Page

### DIFF
--- a/components/transactions/InfiniteTransactionList.tsx
+++ b/components/transactions/InfiniteTransactionList.tsx
@@ -10,15 +10,17 @@ import TransactionItem from "@/components/transactions/TransactionItem";
 import EndOfTransaction from "@/components/transactions/EndOfTransaction";
 
 export default function InfiniteTransactionList() {
-  const { data, status, error, fetchNextPage, hasNextPage } = useInfiniteQuery({
-    queryKey: ["transaction"],
-    queryFn: async ({ pageParam = 0 }) => fetchInfiniteTransactions(pageParam),
-    getNextPageParam: (lastPage) =>
-      lastPage.data.length < TRANSACTION_PER_PAGE_FETCH_LIMIT
-        ? undefined
-        : lastPage.nextOffset,
-    initialPageParam: 0,
-  });
+  const { data, status, error, fetchNextPage, hasNextPage, isFetching } =
+    useInfiniteQuery({
+      queryKey: ["transaction"],
+      queryFn: async ({ pageParam = 0 }) =>
+        fetchInfiniteTransactions(pageParam),
+      getNextPageParam: (lastPage) =>
+        lastPage.data.length < TRANSACTION_PER_PAGE_FETCH_LIMIT
+          ? undefined
+          : lastPage.nextOffset,
+      initialPageParam: 0,
+    });
 
   const { ref, inView } = useInView();
 
@@ -40,8 +42,10 @@ export default function InfiniteTransactionList() {
         </Fragment>
       ))}
 
-      {hasNextPage ? (
-        <InfiniteTransactionSkeletonWrapper ref={ref} />
+      {isFetching ? (
+        <InfiniteTransactionSkeletonWrapper />
+      ) : hasNextPage ? (
+        <div className="transactions-infinite-scroll__trigger" ref={ref} />
       ) : (
         <EndOfTransaction />
       )}

--- a/components/transactions/InfiniteTransactionList.tsx
+++ b/components/transactions/InfiniteTransactionList.tsx
@@ -31,22 +31,20 @@ export default function InfiniteTransactionList() {
   ) : status === "error" ? (
     <p>{error.message}</p>
   ) : (
-    <>
-      <section className="space-y-1">
-        {data.pages.map((page, idx) => (
-          <Fragment key={idx}>
-            {page.data.map((transaction) => (
-              <TransactionItem key={transaction.id} transaction={transaction} />
-            ))}
-          </Fragment>
-        ))}
-      </section>
+    <section className="space-y-1">
+      {data.pages.map((page, idx) => (
+        <Fragment key={idx}>
+          {page.data.map((transaction) => (
+            <TransactionItem key={transaction.id} transaction={transaction} />
+          ))}
+        </Fragment>
+      ))}
 
       {hasNextPage ? (
         <InfiniteTransactionSkeletonWrapper ref={ref} />
       ) : (
         <EndOfTransaction />
       )}
-    </>
+    </section>
   );
 }

--- a/components/transactions/InfiniteTransactionSkeleton.tsx
+++ b/components/transactions/InfiniteTransactionSkeleton.tsx
@@ -14,7 +14,7 @@ export const InfiniteTransactionSkeletonWrapper = forwardRef<
 >((props, ref) => (
   <section
     ref={ref}
-    className="transactions-infinite-scroll__trigger transaction-skeleton__wrapper space-y-1"
+    className="transaction-skeleton__wrapper space-y-1"
     {...props}
   >
     {Array.from({ length: TRANSACTION_PER_PAGE_FETCH_LIMIT }).map((_, idx) => (


### PR DESCRIPTION
---

### Description:
This PR resolves the issue where transaction fetching would stop due to a stale offset value. It also introduces a new `div` element to act as the scroll trigger, while the skeleton loader remains for visual feedback during data loading.

#### Key Changes:
- Fixed the issue where transaction fetching was stopping due to a stale offset value.
- Introduced a new `div` element as the scroll trigger, while keeping the skeleton loader intact for displaying loading progress.

---

### Context:
The issue was initially introduced in #39, where transaction fetching was halting unexpectedly. PR #40 aimed to fix this by addressing the scroll trigger, but the root cause stale offset values, was not fully resolved. 

This PR fully addresses the issue by fixing the stale offset problem and enhancing the trigger mechanism with a dedicated `div`. The skeleton loader continues to provide a loading visual, but the new `div` now acts as the scroll trigger, ensuring infinite scroll functions properly without interruptions.

#### Related Commits:
- `Fix: issue where transaction fetching was stopping due to stale offset value - Krish-Das`
- `Fix: unwanted gap between transaction items and skeleton loader - Krish-Das`
- `Fix: Infinite scroll trigger leaving viewport, stopping data fetching - Krish-Das`