### PR TITLE
Add onboarding recovery flow for incomplete account setup

### DIFF
--- a/convex/userOnboarding.ts
+++ b/convex/userOnboarding.ts
@@ -1,6 +1,8 @@
 import { ConvexError, v } from "convex/values"
 import { vendorAccounts, vendorCategories } from "#lib/seed"
+import { internal } from "./_generated/api"
 import { internalMutation } from "./_generated/server"
+import { mutation } from "./functions"
 import { log } from "./lib/utils"
 
 /**
@@ -90,5 +92,31 @@ export const onboardUser = internalMutation({
       categoriesCreated: vendorCategories.length,
       totalRecords: results.length,
     }
+  },
+})
+
+/**
+ * Retries onboarding for the currently signed-in user.
+ *
+ * This client-callable mutation exists as a recovery path when the normal
+ * webhook-driven onboarding flow did not finish successfully. It resolves the
+ * authenticated user's Clerk subject and delegates to the internal
+ * `onboardUser` mutation.
+ *
+ * Throws a `ConvexError` with code `UNAUTHENTICATED` when no user session is
+ * present.
+ */
+export const retryOnboarding = mutation({
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity()
+    if (!identity)
+      throw new ConvexError({
+        code: "UNAUTHENTICATED",
+        message: "Authentication required.",
+      })
+
+    await ctx.runMutation(internal.userOnboarding.onboardUser, {
+      userId: identity.subject,
+    })
   },
 })

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -2,9 +2,17 @@
 "use client"
 
 import { useEffect } from "react"
+import { OnboardingRecovery } from "@/components/error/onboarding-recovery"
 import { Container } from "@/components/layout/container"
 import { Button } from "@/components/ui/button/animated-button"
 import { Spacer } from "@/components/ui/spacer"
+
+const hasErrorCode = (err: unknown, code: string): boolean => {
+  if (!err || typeof err !== "object") return false
+  const maybeData = (err as { data?: unknown }).data
+  if (!maybeData || typeof maybeData !== "object") return false
+  return (maybeData as { code?: unknown }).code === code
+}
 
 export default function Error({
   error,
@@ -16,6 +24,11 @@ export default function Error({
   useEffect(() => {
     console.error(error)
   }, [error])
+
+  // TODO: use global constants for these error-codes
+  if (hasErrorCode(error, "USER_NOT_STORED")) {
+    return <OnboardingRecovery onRecovered={reset} />
+  }
 
   return (
     <Container className="flex-1 px-4 pt-6">

--- a/src/components/error/onboarding-recovery.tsx
+++ b/src/components/error/onboarding-recovery.tsx
@@ -1,0 +1,62 @@
+import { useMutation } from "convex/react"
+import { useState } from "react"
+import { toast } from "sonner"
+import { api } from "#/convex/_generated/api"
+import { Container } from "@/components/layout/container"
+import { Button } from "@/components/ui/button/animated-button"
+import { Spacer } from "@/components/ui/spacer"
+import { wait } from "@/lib/utils"
+import { Spinner } from "../loading/spinner"
+
+export function OnboardingRecovery({
+  onRecovered,
+}: {
+  onRecovered?: () => void
+}) {
+  const [loading, setLoading] = useState(false)
+  const retryOnboarding = useMutation(api.userOnboarding.retryOnboarding)
+
+  async function handleRetryOnboarding() {
+    if (loading) return
+    setLoading(true)
+    try {
+      await Promise.all([retryOnboarding(), wait(1500)]) // Artificial delay of atleast 1500 ms
+      onRecovered?.()
+    } catch {
+      toast.error("Setup failed, please try again.")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <span className="absolute inset-0 bg-[linear-gradient(to_bottom,color-mix(in_oklch,var(--ios-red)_8%,transparent)_0%,transparent_90%)]" />
+      <Container
+        as="section"
+        className="relative flex flex-1 flex-col px-4 py-6"
+      >
+        <span className="my-24 mt-32 block font-black text-6xl text-[color-mix(in_oklch,var(--ios-red)_90%,var(--ios-yellow))] uppercase">
+          Oops!
+        </span>
+
+        <h1 className="sr-only">Error: Account setup incomplete</h1>
+        <p className="w-fit text-pretty pr-2 text-lg md:text-wrap">
+          Your account wasn't fully set up. This usually fixes itself.{" "}
+          <br className="hidden md:block" />
+          Tap the button below to finish setup.
+        </p>
+        <Spacer className="h-8" />
+        <Button
+          className="disabled:opacity-90"
+          color="gray"
+          isDisabled={loading}
+          onPress={handleRetryOnboarding}
+        >
+          {loading && <Spinner />}
+          Finish setup
+        </Button>
+      </Container>
+    </>
+  )
+}


### PR DESCRIPTION
### Overview
Adds a recovery mechanism for users whose account setup did not complete successfully via the normal webhook-driven onboarding flow. Prevents `USER_NOT_STORED` errors from blocking access by providing a UI path to retry setup.

### Changes
- **`convex/userOnboarding.ts`**: New client-callable `retryOnboarding` mutation that resolves the authenticated user's Clerk subject and delegates to the internal `onboardUser` mutation
- **`src/app/error.tsx`**: Added error boundary detection for `USER_NOT_STORED` code; surfaces the recovery UI when that error is encountered
- **`src/components/error/onboarding-recovery.tsx`**: New recovery component with CTA to retry setup, includes 1.5s artificial delay post-completion and toast feedback on failure

### Implementation details
- `retryOnboarding` is auth-gated; throws `UNAUTHENTICATED` if no session
- Error detection uses a type-safe helper (`hasErrorCode`) to navigate the Convex error structure
- Recovery UI includes visual hierarchy, loading state, and feedback patterns matching app conventions
- Artificial delay ensures Convex mutations have settled before resetting the error boundary

---

**Note:** TODO added in error.tsx to centralize error codes as constants.