### PR TITLE
Fix loading state check in BalanceTrend component

### DIFF
--- a/src/features/charts/BalanceTrend/index.tsx
+++ b/src/features/charts/BalanceTrend/index.tsx
@@ -24,7 +24,7 @@ export function BalanceTrend() {
   })
   const balance = useQuery(api.account.getBalance, { account: "*" })
 
-  if (!(transactions && balance))
+  if (transactions === undefined || balance === undefined)
     return (
       <div className="h-52 w-full p-4">
         <Spinner />


### PR DESCRIPTION
## Overview
Replaces falsy check with explicit `undefined` comparison to correctly handle loading state in the BalanceTrend component.

## Changes
- Changed `if (!(transactions && balance))` to `if (transactions === undefined || balance === undefined)`
- This ensures the loading spinner displays correctly when queries are pending, rather than on zero/empty values

## Notes
The original falsy check would trigger the spinner even when data is legitimately zero or empty, blocking valid renders. Explicit `undefined` checks align with Convex's query behavior where unresolved queries are `undefined` and resolved queries return actual values (including zero).