### PR TITLE
Centralize icon types and add size prop to Spinner

### DIFF
--- a/src/components/icons/social.tsx
+++ b/src/components/icons/social.tsx
@@ -1,8 +1,4 @@
-import type { SVGProps } from "react"
-
-export interface IconProps extends SVGProps<SVGSVGElement> {
-  size?: string | number
-}
+import type { IconProps } from "./types"
 
 // Icon from MingCute Icon by MingCute Design - https://github.com/Richard9394/MingCute/blob/main/LICENSE
 export function MingcuteGithubFill({ size = "1em", ...props }: IconProps) {

--- a/src/components/icons/types.ts
+++ b/src/components/icons/types.ts
@@ -1,0 +1,5 @@
+import type { SVGProps } from "react"
+
+export interface IconProps extends SVGProps<SVGSVGElement> {
+  size?: string | number
+}

--- a/src/components/loading/spinner.tsx
+++ b/src/components/loading/spinner.tsx
@@ -1,14 +1,16 @@
-export function Spinner(props: React.SVGProps<SVGSVGElement>) {
+import type { IconProps } from "../icons/types"
+
+export function Spinner(props: IconProps) {
   return <Icon {...props} />
 }
 
 // Icon from SVG Spinners by Utkarsh Verma - https://github.com/n3r4zzurr0/svg-spinners/blob/main/LICENSE
-export function Icon(props: React.SVGProps<SVGSVGElement>) {
+export function Icon({ size = "1em", ...props }: IconProps) {
   return (
     <svg
-      height="1em"
+      height={size}
       viewBox="0 0 24 24"
-      width="1em"
+      width={size}
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >


### PR DESCRIPTION
**Overview**

Extracts the `IconProps` interface (previously duplicated in `social.tsx`) into a shared `src/components/icons/types.ts`. Updates `Spinner` and `Icon` to use `IconProps`, adding a controllable `size` prop in place of hardcoded `1em` dimensions.

**Changes**

- `icons/types.ts` — new file; exports `IconProps` (`SVGProps<SVGSVGElement> & { size?: string | number }`)
- `icons/social.tsx` — removes local `IconProps` definition, imports from `types.ts`
- `loading/spinner.tsx` — adopts `IconProps`, threads `size` through to `width`/`height` on the SVG (defaults to `"1em"`)