### PR TITLE
Add loading and empty states to the dashboard

### DIFF
--- a/convex/transaction.ts
+++ b/convex/transaction.ts
@@ -8,19 +8,56 @@ import { v as vLib } from "#lib/validators"
 import { internal } from "./_generated/api"
 import type { Doc } from "./_generated/dataModel"
 import { getDoc } from "./lib/doc"
-import { userMutation, userQuery, zUserMutation } from "./lib/userFunctions"
+import {
+  userMutation,
+  userQuery,
+  zUserMutation,
+  zUserQuery,
+} from "./lib/userFunctions"
 import { zid } from "./lib/utils"
 import schema from "./schema"
 
-export const list = userQuery({
-  handler: async (ctx) => {
+/**
+ * Lists the authenticated user's transactions ordered by date.
+ *
+ * @param order - Sort order for the date index. Defaults to `"desc"`.
+ * @param limit - Max rows to return, or `"collect_all"` for all transactions.
+ * @returns The user's transactions in the requested order.
+ *
+ * @example
+ * ```ts
+ * const transactions = useQuery(api.transaction.list, {
+ *   limit: 20,
+ * })
+ * ```
+ *
+ * @example
+ * ```ts
+ * const transactions = useQuery(api.transaction.list, {
+ *   order: "asc",
+ *   limit: "collect_all",
+ * })
+ * ```
+ */
+export const list = zUserQuery({
+  args: z.object({
+    order: z.enum(["asc", "desc"]).default("desc"),
+    limit: z.union([
+      z.literal("collect_all"),
+      z.number().int().finite().min(1),
+    ]),
+  }),
+  handler: async (ctx, { limit, order }) => {
     const { user } = ctx
 
-    return await ctx.db
+    const q = ctx.db
       .query("transactions")
-      .withIndex("by_owner", (q) => q.eq("ownerId", user.ownerId))
-      .order("asc")
-      .collect()
+      .withIndex("by_date", (q) => q.eq("ownerId", user.ownerId))
+      .order(order)
+
+    if (limit === "collect_all") return await q.collect()
+
+    return await q.take(limit)
   },
 })
 

--- a/src/app/(index)/page.tsx
+++ b/src/app/(index)/page.tsx
@@ -1,27 +1,48 @@
+"use client"
+
+import { useQuery } from "convex-helpers/react/cache"
+import { api } from "#/convex/_generated/api"
 import Balance from "@/components/app/summary/Balance"
 import { Container } from "@/components/layout/container"
+import { SplashScreen } from "@/components/loading/splash-screen"
 import { Spacer } from "@/components/ui/spacer"
+import ShinyText from "@/components/ui/text-shimmer"
 import { BalanceTrend } from "@/features/charts/BalanceTrend"
 import { SpendingPace } from "@/features/charts/RemainingBalance"
 import { WeeklyAverage } from "@/features/charts/WeeklyAverage"
 
 export default function Home() {
-  return (
-    <main className="flex-1" data-vaul-drawer-wrapper="">
-      <Container as="section" className="flex flex-col">
-        <div className="mt-32 mb-26 grid place-content-center">
-          <Balance />
-        </div>
-        <div className="px-4">
-          <BalanceTrend />
-          <Spacer className="h-12" />
-          <SpendingPace />
-          <SubHeading>Weekly Average</SubHeading>
-          <WeeklyAverage />
-        </div>
-      </Container>
+  const oldestTransaction = useQuery(api.transaction.list, {
+    limit: 1,
+    order: "asc",
+  })
 
-      <Spacer className="h-[24vh] w-full min-w-1" />
+  if (oldestTransaction === undefined) return <SplashScreen />
+
+  const hasTransactions = oldestTransaction.length > 0
+
+  return (
+    <main className="flex flex-1 flex-col" data-vaul-drawer-wrapper="">
+      <Container as="section" className="flex flex-1 flex-col">
+        <Spacer className="h-32" />
+        <div className="place-content-center">
+          <Balance showDelta={hasTransactions} />
+        </div>
+
+        {hasTransactions ? (
+          <div className="mt-26 px-4">
+            <Spacer className="h-6" />
+            <BalanceTrend />
+            <Spacer className="h-12" />
+            <SpendingPace />
+            <SubHeading>Weekly Average</SubHeading>
+            <WeeklyAverage />
+            <Spacer className="h-[24vh] w-full min-w-1" />
+          </div>
+        ) : (
+          <NoActivity />
+        )}
+      </Container>
     </main>
   )
 }
@@ -32,5 +53,21 @@ const SubHeading = ({ ...props }: React.ComponentProps<"p">) => {
       className="mt-4 w-fit px-4 text-label-secondary text-lg leading-12"
       {...props}
     />
+  )
+}
+
+const NoActivity = () => {
+  return (
+    <div className="flex w-full flex-1 flex-col items-center justify-center pb-4 text-center font-medium text-label-secondary text-lg">
+      <ShinyText
+        ariaLabel="Press plus button to add a transaction"
+        delay={2}
+        direction="left"
+        shineColor="var(--label-primary)"
+        speed={2}
+        spread={65}
+        text="Press 􀁍 to add a transaction"
+      />
+    </div>
   )
 }

--- a/src/components/app/summary/Balance.tsx
+++ b/src/components/app/summary/Balance.tsx
@@ -22,7 +22,7 @@ import { IoArrowDown, IoArrowUp } from "react-icons/io5"
 import { useBalanceOn } from "@/hooks/convex/balance"
 import { CURRENCY } from "@/lib/date-utils"
 
-const Balance = () => {
+const Balance = ({ showDelta }: { showDelta?: boolean }) => {
   const startOfCurrentMonth = startOfMonth(subMonths(new Date(), 0))
   const startOfPreviousMonth = startOfMonth(subMonths(new Date(), 1))
 
@@ -58,23 +58,25 @@ const Balance = () => {
         value={currentBalance / 100}
       />
 
-      <p className="flex items-center text-label-secondary [&_svg]:mr-1 [&_svg]:text-lg">
-        {delta < 0 ? (
-          <IoArrowDown color="var(--ios-red)" />
-        ) : (
-          <IoArrowUp color="var(--ios-green)" />
-        )}
-        <NumberFlow
-          className="mr-[0.5ch]"
-          format={{
-            style: "currency",
-            currency: CURRENCY,
-            trailingZeroDisplay: "stripIfInteger",
-          }}
-          value={Math.abs(delta) / 100}
-        />
-        from last month
-      </p>
+      {showDelta && (
+        <p className="flex items-center text-label-secondary [&_svg]:mr-1 [&_svg]:text-lg">
+          {delta < 0 ? (
+            <IoArrowDown color="var(--ios-red)" />
+          ) : (
+            <IoArrowUp color="var(--ios-green)" />
+          )}
+          <NumberFlow
+            className="mr-[0.5ch]"
+            format={{
+              style: "currency",
+              currency: CURRENCY,
+              trailingZeroDisplay: "stripIfInteger",
+            }}
+            value={Math.abs(delta) / 100}
+          />
+          from last month
+        </p>
+      )}
     </div>
   )
 }

--- a/src/components/loading/splash-screen.tsx
+++ b/src/components/loading/splash-screen.tsx
@@ -1,0 +1,33 @@
+import type { IconProps } from "../icons/types"
+
+export function SplashScreen() {
+  return (
+    <div className="pointer-events-none fixed inset-0 z-100 grid select-none place-content-center bg-background">
+      <span
+        aria-hidden={true}
+        className="animate-pulse text-3xl text-label-secondary leading-none"
+      >
+        <AppIcon />
+      </span>
+      <span className="sr-only">Loading...</span>
+    </div>
+  )
+}
+
+// TODO: Design a good app icon in future
+const AppIcon = ({ size = "1em", ...props }: IconProps) => (
+  <svg
+    fill="currentColor"
+    height={size}
+    viewBox="0 0 26 18"
+    width={size}
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <title>Extrack icon</title>
+    <path
+      d="M25.102 8.977a8.7 8.7 0 0 1-.704 3.48 9 9 0 0 1-1.933 2.871 9.1 9.1 0 0 1-2.86 1.934 8.8 8.8 0 0 1-3.48.691q-.726 0-1.453-.129a10.4 10.4 0 0 0 2.555-2.308 10.7 10.7 0 0 0 1.71-3.036q.61-1.664.61-3.503 0-1.853-.61-3.516a10.5 10.5 0 0 0-1.71-3.024A10.4 10.4 0 0 0 14.672.13a8.7 8.7 0 0 1 4.934.574 8.9 8.9 0 0 1 2.859 1.934 8.9 8.9 0 0 1 1.933 2.86 8.6 8.6 0 0 1 .704 3.48M8.977 17.953a8.8 8.8 0 0 1-3.493-.691 9.3 9.3 0 0 1-2.859-1.934 9.3 9.3 0 0 1-1.934-2.871A8.8 8.8 0 0 1 0 8.977q0-1.865.691-3.48A9.1 9.1 0 0 1 5.484.702 8.7 8.7 0 0 1 8.977 0q1.851 0 3.48.703a8.9 8.9 0 0 1 2.86 1.934 8.9 8.9 0 0 1 1.933 2.86 8.6 8.6 0 0 1 .703 3.48 8.7 8.7 0 0 1-.703 3.48 9 9 0 0 1-1.934 2.871 9.1 9.1 0 0 1-2.859 1.934 8.8 8.8 0 0 1-3.48.691"
+      fill="currentColor"
+    />
+  </svg>
+)

--- a/src/components/ui/text-shimmer.tsx
+++ b/src/components/ui/text-shimmer.tsx
@@ -1,0 +1,160 @@
+/**
+ * Code snippet from reactbits
+ * https://reactbits.dev/text-animations/shiny-text
+ */
+
+"use client"
+
+import {
+  motion,
+  useAnimationFrame,
+  useMotionValue,
+  useTransform,
+} from "motion/react"
+import type React from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
+
+/** Returns progress [0, 100] for a single forward cycle with optional end-delay. */
+function calcLinearProgress(
+  elapsed: number,
+  animationDuration: number,
+  delayDuration: number
+): number {
+  const cycleDuration = animationDuration + delayDuration
+  const cycleTime = elapsed % cycleDuration
+
+  if (cycleTime < animationDuration) {
+    return (cycleTime / animationDuration) * 100
+  }
+
+  return 100
+}
+
+/** Returns progress [0, 100] for a yoyo (forward -> hold -> reverse -> hold) cycle. */
+function calcYoyoProgress(
+  elapsed: number,
+  animationDuration: number,
+  delayDuration: number
+): number {
+  const cycleDuration = animationDuration + delayDuration
+  const fullCycle = cycleDuration * 2
+  const cycleTime = elapsed % fullCycle
+
+  if (cycleTime < animationDuration) {
+    return (cycleTime / animationDuration) * 100
+  }
+
+  if (cycleTime < cycleDuration) {
+    return 100
+  }
+
+  if (cycleTime < cycleDuration + animationDuration) {
+    const reverseTime = cycleTime - cycleDuration
+    return 100 - (reverseTime / animationDuration) * 100
+  }
+
+  return 0
+}
+
+interface ShinyTextProps {
+  text: string
+  ariaLabel?: string
+  disabled?: boolean
+  speed?: number
+  className?: string
+  color?: string
+  shineColor?: string
+  spread?: number
+  yoyo?: boolean
+  pauseOnHover?: boolean
+  direction?: "left" | "right"
+  delay?: number
+}
+
+const ShinyText: React.FC<ShinyTextProps> = ({
+  text,
+  ariaLabel,
+  disabled = false,
+  speed = 2,
+  className = "",
+  color = "#b5b5b5",
+  shineColor = "#ffffff",
+  spread = 120,
+  yoyo = false,
+  pauseOnHover = false,
+  direction = "left",
+  delay = 0,
+}) => {
+  const [isPaused, setIsPaused] = useState(false)
+  const progress = useMotionValue(0)
+  const elapsedRef = useRef(0)
+  const lastTimeRef = useRef<number | null>(null)
+  const directionRef = useRef(direction === "left" ? 1 : -1)
+
+  const animationDuration = speed * 1000
+  const delayDuration = delay * 1000
+
+  useAnimationFrame((time) => {
+    if (disabled || isPaused) {
+      lastTimeRef.current = null
+      return
+    }
+
+    if (lastTimeRef.current === null) {
+      lastTimeRef.current = time
+      return
+    }
+
+    const deltaTime = time - lastTimeRef.current
+    lastTimeRef.current = time
+    elapsedRef.current += deltaTime
+
+    const p = yoyo
+      ? calcYoyoProgress(elapsedRef.current, animationDuration, delayDuration)
+      : calcLinearProgress(elapsedRef.current, animationDuration, delayDuration)
+
+    progress.set(directionRef.current === 1 ? p : 100 - p)
+  })
+
+  useEffect(() => {
+    directionRef.current = direction === "left" ? 1 : -1
+    elapsedRef.current = 0
+    progress.set(directionRef.current === 1 ? 0 : 100)
+  }, [direction, progress])
+
+  // Transform: p=0 -> 150% (shine off right), p=100 -> -50% (shine off left)
+  const backgroundPosition = useTransform(
+    progress,
+    (p) => `${150 - p * 2}% center`
+  )
+
+  const handleMouseEnter = useCallback(() => {
+    if (pauseOnHover) setIsPaused(true)
+  }, [pauseOnHover])
+
+  const handleMouseLeave = useCallback(() => {
+    if (pauseOnHover) setIsPaused(false)
+  }, [pauseOnHover])
+
+  const gradientStyle: React.CSSProperties = {
+    backgroundImage: `linear-gradient(${spread}deg, ${color} 0%, ${color} 35%, ${shineColor} 50%, ${color} 65%, ${color} 100%)`,
+    backgroundSize: "200% auto",
+    WebkitBackgroundClip: "text",
+    backgroundClip: "text",
+    WebkitTextFillColor: "transparent",
+  }
+
+  return (
+    <motion.span
+      aria-label={ariaLabel}
+      className={`inline-block ${className}`}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      style={{ ...gradientStyle, backgroundPosition }}
+    >
+      {text}
+    </motion.span>
+  )
+}
+
+export default ShinyText


### PR DESCRIPTION
**Overview**

The home page previously had no loading state and always rendered charts regardless of whether the user had any transactions. This PR adds a splash screen shown during auth and data loading, an empty state for new users with no transactions, and conditionally hides the month-over-month delta when there's no history to compare against.

**Changes**

- `transaction.list` — switched from `userQuery` to `zUserQuery`; accepts `limit` (positive integer or `"collect_all"`) and `order` (`"asc"` | `"desc"`, defaults to `"desc"`); results now sorted by date via `by_date` index instead of `by_owner`
- `Balance` — accepts optional `showDelta` prop; hides the month-over-month comparison row when `false`
- Home page — converted to a client component; shows `SplashScreen` while auth or the oldest-transaction query is loading; renders charts when transactions exist, `NoActivity` prompt otherwise
- `SplashScreen` — full-screen centered overlay with a pulsing app icon and a screen-reader-visible "Loading..." label; icon is a placeholder pending final design
- `ShinyText` — vendored animation component from reactbits; supports configurable speed, direction, shine color, spread, yoyo, and pause-on-hover

**Notes**

- `ShinyText` is a vendored copy from [reactbits.dev](https://reactbits.dev/text-animations/shiny-text). Source is attributed in the file header. Upstream bug fixes won't propagate automatically.
- The empty state uses `transaction.list` with `limit: 1` as a cheap proxy for "has any transactions." No dedicated query added.