### PR TITLE
Add dynamic favicon for development environment

### DIFF
--- a/src/components/dev/README.md
+++ b/src/components/dev/README.md
@@ -1,0 +1,3 @@
+# development components
+
+Components for development use only. Never import these in production code.

--- a/src/components/dev/dynamic-favicon.tsx
+++ b/src/components/dev/dynamic-favicon.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { useEffect } from "react"
+
+const DEV_FAVICON_PATH = "/favicon.ico"
+const ICON_SELECTOR =
+  "link[rel='icon'], link[rel='shortcut icon'], link[rel='apple-touch-icon']"
+
+/**
+ * Sets the development favicon when mounted (persists after unmount).
+ */
+export function DynamicFavicon() {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "development") return
+
+    const faviconUrl = new URL(DEV_FAVICON_PATH, window.location.origin)
+    faviconUrl.searchParams.set("v", Date.now().toString())
+
+    const iconLinks = document.querySelectorAll<HTMLLinkElement>(ICON_SELECTOR)
+
+    for (const iconLink of iconLinks) {
+      iconLink.href = faviconUrl.toString()
+    }
+
+    if (iconLinks.length > 0) return
+
+    const iconLink = document.createElement("link")
+    iconLink.rel = "icon"
+    iconLink.href = faviconUrl.toString()
+    document.head.appendChild(iconLink)
+  }, [])
+
+  return null
+}


### PR DESCRIPTION
## Overview

Adds a development-only component that dynamically sets the app's favicon to a custom dev image on mount. Includes cache-busting via timestamp query parameter to ensure fresh favicon on dev server restarts.

## Changes

- **`src/components/dev/dynamic-favicon.tsx`** – New client component that queries existing favicon links and updates their `href` attributes, or creates a new favicon link if none exist. Only runs in development mode.
- **`src/components/dev/README.md`** – Documentation clarifying dev components are for development use only.

## Notes

- Cache buster prevents stale favicon caching during development
- Component returns `null` (no DOM impact)
- Guard: `process.env.NODE_ENV !== "development"` ensures no effect in production builds