### PR TITLE
Show user avatar in settings button

### DIFF
--- a/src/components/app/header/SettingsButton.tsx
+++ b/src/components/app/header/SettingsButton.tsx
@@ -1,12 +1,24 @@
 "use client"
 
+import { Avatar } from "@base-ui/react/avatar"
+import { useUser } from "@clerk/nextjs"
 import Link from "next/link"
-import { IoPersonCircle } from "react-icons/io5"
+import { useEffect, useState } from "react"
+import { getInitials } from "@/components/user/helpers"
 
 export function SettingsButton() {
+  const [isMounted, setIsMounted] = useState(false)
+  const { user, isSignedIn, isLoaded } = useUser()
+
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  if (!(isMounted && isLoaded && isSignedIn && user)) return null
+
   return (
     <Link
-      className="h-fit w-fit cursor-default"
+      className="size-8"
       href="/settings"
       style={
         // TODO: extract these options to somewhere reasonable
@@ -22,7 +34,24 @@ export function SettingsButton() {
         } as React.CSSProperties
       }
     >
-      <IoPersonCircle aria-hidden="true" />
+      <Avatar.Root
+        aria-hidden="true"
+        className="inline-flex size-8 select-none items-center justify-center overflow-hidden rounded-full bg-background-primary-elevated align-middle font-normal text-label-secondary text-sm leading-none"
+      >
+        <Avatar.Image
+          className="size-full object-cover"
+          height="32"
+          src={user.imageUrl}
+          width="32"
+        />
+        <Avatar.Fallback
+          className="flex size-full items-center justify-center text-sm"
+          delay={600}
+        >
+          {getInitials(user.fullName)}
+        </Avatar.Fallback>
+      </Avatar.Root>
+
       <span className="sr-only">Settings</span>
     </Link>
   )


### PR DESCRIPTION
Replace the generic profile icon with the signed-in user's avatar.

Fall back to the user's initials while the image loads, and hide the button entirely when no authenticated user is available.