### PR TITLE
Show centered pill toast on successful transaction add

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -75,6 +75,34 @@ body {
   );
 }
 
+/* Sonner notification toaster: content-sized pills, no 356px track */
+[data-sonner-toaster].sonner-notification {
+  width: auto !important;
+}
+
+[data-sonner-toaster].sonner-notification [data-sonner-toast] {
+  left: 50%;
+  right: auto;
+  width: fit-content;
+  max-width: calc(100vw - 32px);
+  transform: translateX(-50%) var(--y);
+}
+
+[data-sonner-toaster].sonner-notification
+  [data-sonner-toast][data-swiping="true"] {
+  transform: translateX(-50%) var(--y) translateY(var(--swipe-amount-y, 0px))
+    translateX(var(--swipe-amount-x, 0px));
+}
+
+@media (max-width: 600px) {
+  [data-sonner-toaster].sonner-notification {
+    left: 50% !important;
+    right: auto !important;
+    transform: translateX(-50%) !important;
+    width: auto !important;
+  }
+}
+
 /* Tailwind v4 — iOS elevation tokens */
 @theme {
   /* Low — cards, inputs */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -64,6 +64,11 @@ export default function RootLayout({
       <body className="flex min-h-dvh flex-col">
         <Provider>{children}</Provider>
         <Toaster id="default" position="bottom-right" />
+        <Toaster
+          className="sonner-notification"
+          id="notification"
+          position="top-center"
+        />
         <SpeedInsights />
       </body>
     </html>

--- a/src/components/transaction/new-form/hooks/use-new-transaction-form.ts
+++ b/src/components/transaction/new-form/hooks/use-new-transaction-form.ts
@@ -9,6 +9,7 @@ import { api } from "#/convex/_generated/api"
 import type { Id } from "#/convex/_generated/dataModel"
 import type { TransactionTypes } from "#lib/constants/transaction-types"
 import { type NewTransactionSchemaType, newTransactionSchema } from "../schema"
+import { showTransactionToast } from "../transaction-toast"
 import { useAppForm } from "./form-context"
 
 export function useNewTransactionForm(
@@ -74,21 +75,43 @@ export function useNewTransactionForm(
     } as unknown as z.input<typeof newTransactionSchema>,
     onSubmit: ({ value: data }) => {
       const parsedData = data as NewTransactionSchemaType
-      createTransaction({
+
+      const category = context?.categories.find(
+        (cat) => cat._id === parsedData.category
+      )
+
+      // Start the mutation but don't block
+      const mutationPromise = createTransaction({
         amount: parsedData.amount * 100, // dollars to cents
         category: parsedData.category as Id<"categories">,
         account: parsedData.account as Id<"accounts">,
         date: parsedData.date,
         type: parsedData.type,
         note: parsedData.note,
-      }).catch((err) => {
-        toast.error("Failed to add transaction", {
-          description:
-            err instanceof ConvexError ? err.data.message : "Unknown err",
-        })
       })
 
+      // Run afterSubmit immediately without waiting
       afterSubmit?.(parsedData)
+
+      // Wait for mutation to determine toast type
+      mutationPromise
+        .then(() => {
+          showTransactionToast({
+            type: parsedData.type,
+            amount: parsedData.amount,
+            categoryName: category?.name ?? "Unknown",
+            emoji: category?.icon ?? "❓",
+            color: category?.color ?? "red",
+          })
+        })
+        .catch((err) => {
+          toast.error(`Failed to add ${parsedData.type}`, {
+            description:
+              err instanceof ConvexError
+                ? err.data.message
+                : "Unknown error occurred",
+          })
+        })
     },
   })
 

--- a/src/components/transaction/new-form/transaction-toast-pill.tsx
+++ b/src/components/transaction/new-form/transaction-toast-pill.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { LuArrowDown, LuArrowUp } from "react-icons/lu"
+import type { Colors } from "#lib/constants/colors"
+import type { TransactionTypes } from "#lib/constants/transaction-types"
+import { Emoji } from "@/components/ui/emoji"
+import { useCurrencyFormatter } from "@/hooks/useCurrencyFormatter"
+import { cn } from "@/lib/utils"
+
+export type TransactionToastPillProps = {
+  type: TransactionTypes
+  amount: number
+  categoryName: string
+  emoji: string
+  color: Colors
+}
+
+export function TransactionToastPill({
+  type,
+  amount,
+  categoryName,
+  emoji,
+  color,
+}: TransactionToastPillProps) {
+  const isExpense = type === "expense"
+  const TransactionIcon = isExpense ? LuArrowDown : LuArrowUp
+
+  const formatter = useCurrencyFormatter()
+  const formattedAmount = formatter.format(amount)
+  const amountClasses = isExpense ? "text-ios-red" : "text-ios-green"
+
+  return (
+    <div
+      className={cn(
+        "flex h-fit w-fit max-w-none shrink-0 select-none flex-nowrap items-center gap-2 whitespace-nowrap rounded-full bg-background-primary-elevated p-2.5 font-rnx-rounded",
+        "shadow-2xl shadow-black/12 dark:shadow-black/20 dark:shadow-xl",
+        "border border-gray-6 dark:border-gray-5/50"
+      )}
+      style={
+        {
+          "--toast-color": `var(--ios-${color}, var(--gray-1))`,
+        } as React.CSSProperties
+      }
+    >
+      <Emoji className="inline-grid size-8 place-content-center rounded-full bg-(--toast-color)/(--fill-tertiary-opacity) font-medium text-sm ring ring-(--toast-color)/15 dark:ring-(--toast-color)/30">
+        {emoji}
+      </Emoji>
+      <span className="mr-1 shrink-0 whitespace-nowrap">{categoryName}</span>
+      <span
+        className={cn(
+          "mr-px inline-flex shrink-0 items-center gap-0.5 whitespace-nowrap align-middle font-semibold leading-none tracking-tight",
+          amountClasses
+        )}
+      >
+        <TransactionIcon aria-hidden="true" size={19} strokeWidth={2.25} />
+        {formattedAmount}
+      </span>
+    </div>
+  )
+}

--- a/src/components/transaction/new-form/transaction-toast.tsx
+++ b/src/components/transaction/new-form/transaction-toast.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import { toast } from "sonner"
+import type { Colors } from "#lib/constants/colors"
+import type { TransactionTypes } from "#lib/constants/transaction-types"
+import { TransactionToastPill } from "./transaction-toast-pill"
+
+export type TransactionToast = {
+  type: TransactionTypes
+  amount: number
+  categoryName: string
+  emoji: string
+  color: Colors
+}
+
+export function showTransactionToast(props: TransactionToast) {
+  toast.custom(() => <TransactionToastPill {...props} />, {
+    toasterId: "notification",
+    className: "flex w-full justify-center",
+  })
+}


### PR DESCRIPTION
## Overview

Shows a custom pill toast at the top-center of the screen after a transaction is successfully added. The pill displays the category emoji, name, and signed amount with type-driven color.

## Changes

- Added a second `<Toaster>` instance (`id="notification"`) positioned `top-center` for non-blocking success feedback
- Custom CSS overrides on `.sonner-notification` to make the toaster content-sized (not fixed 356px) and properly centered via `translateX(-50%)` — including swipe state and mobile breakpoint handling
- `TransactionToastPill` — pill component rendering emoji, category name, and amount with income/expense styling
- `showTransactionToast` — calls `toast.custom()` targeting the `notification` toaster
- Form submit now fires `afterSubmit` immediately (non-blocking), then resolves the mutation promise to either show the success pill or fall back to the existing error toast

## Screenshot

<img width="1170" height="1178" alt="ss-toast-edited" src="https://github.com/user-attachments/assets/3a5c5567-96e7-4352-b24e-f5d7ad0f1641" />