### PR TITLE
Route app toasts through the default toaster

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -63,7 +63,7 @@ export default function RootLayout({
     >
       <body className="flex min-h-dvh flex-col">
         <Provider>{children}</Provider>
-        <Toaster />
+        <Toaster id="default" position="bottom-right" />
         <SpeedInsights />
       </body>
     </html>

--- a/src/app/onboarding/_comps/OnboardingBalanceForm.tsx
+++ b/src/app/onboarding/_comps/OnboardingBalanceForm.tsx
@@ -72,7 +72,9 @@ export function OnboardingBalanceForm({
       push("/")
     } catch {
       setLoading("idle")
-      toast.error("We couldn't save your balance. Please try again.")
+      toast.error("We couldn't save your balance. Please try again.", {
+        toasterId: "default",
+      })
     }
   }
 

--- a/src/app/settings/accounts/[id]/local-comps/AccountInfo.tsx
+++ b/src/app/settings/accounts/[id]/local-comps/AccountInfo.tsx
@@ -65,6 +65,7 @@ export default function AccountInfo() {
       toast.error("Failed to update account", {
         description:
           err instanceof ConvexError ? err.data.message : "Unknown err",
+        toasterId: "default",
       })
     })
     setEditing(false)

--- a/src/app/settings/profile/_comp/ProfileSettings.tsx
+++ b/src/app/settings/profile/_comp/ProfileSettings.tsx
@@ -41,9 +41,13 @@ export function ProfileSettings() {
   const copyUserId = async () => {
     try {
       await navigator.clipboard.writeText(user.id)
-      toast.success("Copied Clerk user ID")
+      toast.success("Copied Clerk user ID", {
+        toasterId: "default",
+      })
     } catch {
-      toast.error("Could not copy User ID")
+      toast.error("Could not copy User ID", {
+        toasterId: "default",
+      })
     }
   }
 
@@ -53,7 +57,9 @@ export function ProfileSettings() {
       await signOut({ redirectUrl: "/sign-in" })
     } catch {
       setIsSigningOut(false)
-      toast.error("Could not sign out")
+      toast.error("Could not sign out", {
+        toasterId: "default",
+      })
     }
   }
 

--- a/src/components/error/onboarding-recovery.tsx
+++ b/src/components/error/onboarding-recovery.tsx
@@ -23,7 +23,9 @@ export function OnboardingRecovery({
       await Promise.all([retryOnboarding(), wait(1500)]) // Artificial delay of atleast 1500 ms
       onRecovered?.()
     } catch {
-      toast.error("Setup failed, please try again.")
+      toast.error("Setup failed, please try again.", {
+        toasterId: "default",
+      })
     } finally {
       setLoading(false)
     }

--- a/src/components/form/account/new/index.tsx
+++ b/src/components/form/account/new/index.tsx
@@ -43,6 +43,7 @@ export function Form({ afterSumbmit }: { afterSumbmit?: () => void }) {
       toast.error("Failed to create account", {
         description:
           err instanceof ConvexError ? err.data.message : "Unknown err",
+        toasterId: "default",
       })
     })
   }


### PR DESCRIPTION
 ## Summary

Route app-level toast messages through the default toaster.

## Changes

- Add `id="default"` to the root `Toaster`
- Set `toasterId: "default"` on existing app toast calls that did not specify one