### PR TITLE
Destructure push from useRouter instead of using router object directly

### DIFF
--- a/src/app/settings/accounts/[id]/local-comps/DeleteAccount.tsx
+++ b/src/app/settings/accounts/[id]/local-comps/DeleteAccount.tsx
@@ -12,13 +12,13 @@ import { Spacer } from "@/components/ui/spacer"
 export function DeleteAccount({ account }: { account: Doc<"accounts"> }) {
   const [open, setOpen] = useState(false)
   const deleteAccount = useMutation(api.account.delete)
-  const router = useRouter()
+  const { push } = useRouter()
 
   const onDelete = () => {
     deleteAccount({ id: account._id })
 
     setOpen(false)
-    router.push("/settings/accounts")
+    push("/settings/accounts")
   }
 
   return (

--- a/src/app/settings/accounts/[id]/local-comps/Header.tsx
+++ b/src/app/settings/accounts/[id]/local-comps/Header.tsx
@@ -20,7 +20,7 @@ export function Header({
   form: UseFormReturn<UpdateAccountSchemaType>
   onSubmit: (_: UpdateAccountSchemaType) => void
 }) {
-  const router = useRouter()
+  const { push } = useRouter()
   const href = "/settings/accounts" as const
   const variants: Variants = {
     initial: { filter: "blur(3px)", scale: 0, opacity: 0 },
@@ -47,7 +47,7 @@ export function Header({
             form.reset()
             return
           }
-          router.push(href, { scroll: false })
+          push(href, { scroll: false })
         }}
       >
         <AnimatePresence key={isEditing ? "T" : "F"} mode="sync">

--- a/src/components/app/dock/src/Idle.tsx
+++ b/src/components/app/dock/src/Idle.tsx
@@ -13,12 +13,12 @@ const IdleNav = () => {
 }
 
 function NavButton({ children, url }: { children: ReactNode; url: string }) {
-  const router = useRouter()
+  const { push } = useRouter()
   const pathname = usePathname().trim()
 
   function navigate(url: string) {
     if (url === pathname) return
-    router.push(url)
+    push(url)
   }
   return (
     <Button

--- a/src/components/app/floating-nav/Navigation.tsx
+++ b/src/components/app/floating-nav/Navigation.tsx
@@ -7,7 +7,7 @@ import { Material } from "@/components/material/material"
 import { cn, wait } from "@/lib/utils"
 
 function Root({ children }: { children: React.ReactNode }) {
-  const router = useRouter()
+  const { push } = useRouter()
   const pathname = usePathname()
   const [tab, setTab] = useState<string>(pathname)
 
@@ -16,7 +16,7 @@ function Root({ children }: { children: React.ReactNode }) {
       onValueChange={async (v) => {
         setTab(v)
         await wait(200)
-        router.push(v)
+        push(v)
       }}
       render={<nav />}
       value={tab}

--- a/src/components/provider/index.tsx
+++ b/src/components/provider/index.tsx
@@ -22,14 +22,14 @@ const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL || "", {
 })
 
 export default function Provider({ children }: { children: ReactNode }) {
-  const router = useRouter()
+  const { push } = useRouter()
 
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
       <ClerkProvider>
         <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
           <ConvexQueryCacheProvider>
-            <RouterProvider navigate={router.push}>{children}</RouterProvider>
+            <RouterProvider navigate={push}>{children}</RouterProvider>
           </ConvexQueryCacheProvider>
         </ConvexProviderWithClerk>
       </ClerkProvider>

--- a/src/components/ui/navigation-header/header.tsx
+++ b/src/components/ui/navigation-header/header.tsx
@@ -17,7 +17,7 @@ export interface HeaderProps {
  * @deprecated Use `PageHeader` from `@/components/navigation/page-header` instead.
  */
 export function Header({ title, srOnly = false, href = "" }: HeaderProps) {
-  const router = useRouter()
+  const { push } = useRouter()
 
   return (
     // NOTE: These heights are coming from button's height
@@ -41,7 +41,7 @@ export function Header({ title, srOnly = false, href = "" }: HeaderProps) {
         )}
         color="gray"
         isIconOnly
-        onPress={() => router.push(href, { scroll: false })}
+        onPress={() => push(href, { scroll: false })}
       >
         􀆉
       </Button>


### PR DESCRIPTION
## Overview

Replaces `router.push(...)` calls with destructured `push` from `useRouter()` across 6 components. No behavior changes.

## Changes

- `DeleteAccount.tsx`, `Header.tsx` (accounts settings), `Idle.tsx`, `Navigation.tsx`, `provider/index.tsx`, `navigation-header/header.tsx` — destructure `{ push }` from `useRouter()` instead of holding the full router object