### PR TITLE
Replace categories settings content with filtered category management screen

### DIFF
--- a/src/app/settings/categories/_comps/CategoryActionsMenu.tsx
+++ b/src/app/settings/categories/_comps/CategoryActionsMenu.tsx
@@ -1,0 +1,384 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation } from "convex/react"
+import { ConvexError } from "convex/values"
+import { EmojiPicker } from "frimousse"
+import { useState } from "react"
+import {
+  Input,
+  Label,
+  ListBox,
+  ListBoxItem,
+  Form as RacForm,
+  TextField,
+} from "react-aria-components"
+import { Controller, type UseFormReturn, useForm } from "react-hook-form"
+import { SlOptionsVertical } from "react-icons/sl"
+import { toast } from "sonner"
+import { api } from "#/convex/_generated/api"
+import type { Doc } from "#/convex/_generated/dataModel"
+import { type Colors, colors } from "#lib/constants/colors"
+import { limit } from "#lib/constants/constraints"
+import { Spinner } from "@/components/loading/spinner"
+import { Button } from "@/components/ui/button/animated-button"
+import { ActionDrawer, DrawerV2 as Drawer } from "@/components/ui/drawer"
+import { List } from "@/components/ui/list-v2"
+import { Spacer } from "@/components/ui/spacer"
+import {
+  type NewCategorySchemaType,
+  newCategorySchema,
+} from "@/lib/schema/categories"
+import { cn, sanitizeName } from "@/lib/utils"
+
+export function CategoryActionsMenu({
+  category,
+}: {
+  category: Doc<"categories">
+}) {
+  const [open, setOpen] = useState(false)
+  const deleteCategory = useMutation(api.category.delete)
+  const handleDelete = () => {
+    // TODO: Add delete error handling when this component is revisited.
+    deleteCategory({ id: category._id })
+    setOpen(false)
+  }
+
+  return (
+    <ActionDrawer.Root onOpenChange={setOpen} open={open}>
+      <Button
+        aria-label={`Actions for ${category.name}`}
+        className="touch-auto"
+        color="gray"
+        isIconOnly
+        onPress={() => setOpen(true)}
+        size="sm"
+        variant="ghost"
+      >
+        <SlOptionsVertical size={16} />
+      </Button>
+      <ActionDrawer.Content>
+        <ActionDrawer.Header>
+          <ActionDrawer.Title srOnly>Actions</ActionDrawer.Title>
+        </ActionDrawer.Header>
+
+        <ActionDrawer.Footer>
+          <EditCategory afterEdit={() => setOpen(false)} category={category} />
+          <DeleteCategory category={category} onDelete={handleDelete} />
+        </ActionDrawer.Footer>
+      </ActionDrawer.Content>
+    </ActionDrawer.Root>
+  )
+}
+
+function EditCategory({
+  category,
+  afterEdit,
+}: {
+  category: Doc<"categories">
+  afterEdit?: () => void
+}) {
+  const update = useMutation(api.category.update)
+  const form = useForm<NewCategorySchemaType>({
+    defaultValues: {
+      type: category.type,
+      name: category.name,
+      color: category.color,
+      icon: category.icon,
+    },
+    resolver: zodResolver(newCategorySchema),
+  })
+  const {
+    formState: { isDirty },
+  } = form
+
+  const editable = isDirty
+
+  const onSubmit = (data: NewCategorySchemaType) => {
+    const { name, icon, color } = data
+
+    update({ id: category._id, name, icon, color }).catch((err) => {
+      toast.error("Failed to update this category", {
+        toasterId: "default",
+        description:
+          err instanceof ConvexError
+            ? `${err.data.message} Please try again.`
+            : "Unknown error occurred. Please try again.",
+      })
+    })
+    afterEdit?.()
+  }
+
+  return (
+    <Drawer.NestedRoot shouldScaleBackground={false}>
+      <Drawer.Trigger asChild>
+        <ActionDrawer.Action>Edit</ActionDrawer.Action>
+      </Drawer.Trigger>
+
+      <Drawer.Content className="h-full">
+        <Drawer.Header>
+          <Drawer.Title srOnly>Edit {category.name}</Drawer.Title>
+          <Drawer.Close />
+        </Drawer.Header>
+
+        <RacForm className="px-4" onSubmit={form.handleSubmit(onSubmit)}>
+          <EmojiSelect form={form} />
+          <Spacer className="h-4" />
+
+          <SelectColor form={form} />
+          <Spacer className="h-4" />
+
+          <NameInput form={form} />
+          <Spacer className="h-4" />
+
+          <Drawer.ClosePrimitive asChild>
+            <Button
+              fullWidth
+              isDisabled={!editable}
+              type="submit"
+              variant="filled"
+            >
+              Done
+            </Button>
+          </Drawer.ClosePrimitive>
+        </RacForm>
+        <Spacer className="h-4" />
+      </Drawer.Content>
+    </Drawer.NestedRoot>
+  )
+}
+
+function DeleteCategory({
+  category,
+  onDelete,
+}: {
+  category: Doc<"categories">
+  onDelete: () => void
+}) {
+  const canDelete = category.is_vendor === false
+
+  if (!canDelete)
+    return (
+      <List.Text className="text-center" level="footer">
+        Built-in categories can’t be deleted
+      </List.Text>
+    )
+
+  return (
+    <ActionDrawer.Root>
+      <ActionDrawer.Trigger asChild>
+        <ActionDrawer.Action color="red">Delete</ActionDrawer.Action>
+      </ActionDrawer.Trigger>
+      <ActionDrawer.Content>
+        <ActionDrawer.Header>
+          <ActionDrawer.Title>Delete {category.name}?</ActionDrawer.Title>
+
+          <ActionDrawer.Description>
+            You are about to delete this category. All your transactions with
+            this category will be deleted as well!
+          </ActionDrawer.Description>
+        </ActionDrawer.Header>
+
+        <ActionDrawer.Footer>
+          <ActionDrawer.ClosePrimitive asChild>
+            <ActionDrawer.Action>Cancel</ActionDrawer.Action>
+          </ActionDrawer.ClosePrimitive>
+
+          <ActionDrawer.ClosePrimitive asChild>
+            <ActionDrawer.Action
+              color="red"
+              onPress={onDelete}
+              variant="filled"
+            >
+              Confirm Delete
+            </ActionDrawer.Action>
+          </ActionDrawer.ClosePrimitive>
+        </ActionDrawer.Footer>
+      </ActionDrawer.Content>
+    </ActionDrawer.Root>
+  )
+}
+
+const colorOptions: { color: Colors }[] = colors.map((color) => ({
+  color,
+}))
+function SelectColor({ form }: { form: UseFormReturn<NewCategorySchemaType> }) {
+  return (
+    <Controller
+      control={form.control}
+      name="color"
+      render={({ field: { value, onChange, onBlur, ref } }) => (
+        <ListBox
+          aria-label="colors"
+          className="flex w-full items-center justify-center gap-0.5 px-0.5 sm:gap-2"
+          disallowEmptySelection
+          items={colorOptions}
+          onBlur={onBlur}
+          onSelectionChange={([key]) => onChange(key as Colors)}
+          orientation="horizontal"
+          ref={ref}
+          selectedKeys={[value]}
+          selectionMode="single"
+          shouldFocusWrap
+        >
+          {({ color }) => (
+            <ListBoxItem
+              className={cn(
+                "relative h-10 w-full rounded-full border-none bg-(--swatch-color) outline-none ring-ios-blue ring-offset-2 ring-offset-background data-focus-visible:ring-2",
+                "after:pointer-events-none after:absolute after:top-1/2 after:left-1/2 after:-translate-x-1/2 after:-translate-y-1/2 after:select-none after:text-sm after:text-white/90 after:opacity-0 after:mix-blend-plus-lighter after:transition-opacity after:content-['􀀁'] data-selected:after:opacity-100"
+              )}
+              id={color}
+              key={color}
+              style={
+                {
+                  "--swatch-color":
+                    color === "gray" ? "var(--gray-1)" : `var(--ios-${color})`,
+                } as React.CSSProperties
+              }
+            />
+          )}
+        </ListBox>
+      )}
+    />
+  )
+}
+
+function NameInput({ form }: { form: UseFormReturn<NewCategorySchemaType> }) {
+  return (
+    <Controller
+      control={form.control}
+      name="name"
+      render={({
+        field: { name, value, onChange, onBlur, ref },
+        fieldState: { invalid },
+      }) => (
+        <>
+          <TextField
+            className="w-full"
+            isInvalid={invalid}
+            isRequired
+            maxLength={limit.name.category.max}
+            minLength={limit.name.category.min}
+            name={name}
+            onBlur={onBlur}
+            onChange={(v) => onChange(sanitizeName(v, limit.name.category.max))}
+            validationBehavior="aria"
+            value={value}
+          >
+            <Label className="w-full px-4 pt-6 pb-1.5 font-medium text-label-secondary text-sm uppercase">
+              Name
+            </Label>
+            <Input
+              className={cn(
+                "h-12 w-full rounded-xl bg-fill-quaternary pr-8.5 pl-4 text-lg leading-none tracking-[0.01em] placeholder-label-secondary",
+                "outline-none data-focus-visible:rounded data-focus-visible:ring-4 data-focus-visible:ring-ios-blue/(--separator-non-opaque-opacity)"
+              )}
+              placeholder="Enter name"
+              ref={ref}
+            />
+          </TextField>
+        </>
+      )}
+    />
+  )
+}
+
+function EmojiSelect({ form }: { form: UseFormReturn<NewCategorySchemaType> }) {
+  const [open, setOpen] = useState(false)
+  const selectedIcon = form.getValues("icon")
+  const selectedColor = form.watch("color")
+
+  return (
+    <>
+      <Spacer className="h-4" />
+
+      <Drawer.NestedRoot onOpenChange={setOpen} open={open} showHandle>
+        <div className="inline-grid w-full place-content-center">
+          <Drawer.Trigger asChild>
+            <Button
+              className="size-32 overflow-hidden rounded-full font-rnx-rounded text-6xl text-white sm:size-38 sm:text-6xl"
+              color={selectedColor}
+              size="lg"
+              variant="tinted"
+            >
+              {selectedIcon}
+            </Button>
+          </Drawer.Trigger>
+        </div>
+
+        <Drawer.Content className="h-full">
+          <Drawer.Header className="sr-only">
+            <Drawer.Title>Select emoji</Drawer.Title>
+          </Drawer.Header>
+
+          <Controller
+            control={form.control}
+            name="icon"
+            render={({ field: { onChange, ref } }) => {
+              return (
+                <EmojiPicker.Root
+                  className="flex h-full w-full flex-col px-4"
+                  columns={9}
+                  onEmojiSelect={({ emoji }) => {
+                    onChange(emoji)
+                    setOpen(false)
+                  }}
+                  ref={ref}
+                >
+                  <Spacer className="h-1" />
+                  <EmojiPicker.Search
+                    className={cn(
+                      "z-10 h-12 w-full appearance-none rounded-[0.6rem] bg-fill-quaternary pr-8.5 pl-3.5 text-lg leading-none tracking-[0.01em] placeholder-label-secondary sm:h-10 sm:pr-7.5",
+                      "outline-none data-focus-visible:ring-4 data-focus-visible:ring-ios-blue/(--separator-non-opaque-opacity)",
+                      "[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none"
+                    )}
+                  />
+                  <Spacer className="h-4" />
+                  <EmojiPicker.Viewport className="flex-1 outline-hidden">
+                    <EmojiPicker.Loading className="absolute inset-0 flex items-center justify-center text-label-secondary text-sm">
+                      <Spinner />
+                    </EmojiPicker.Loading>
+                    <EmojiPicker.Empty className="pointer-events-none absolute inset-0 inline-grid select-none place-content-center font-medium text-base text-label-tertiary tracking-[0.0125em]">
+                      No emoji found.
+                    </EmojiPicker.Empty>
+
+                    <EmojiPicker.List
+                      className="select-none pb-1.5"
+                      components={{
+                        CategoryHeader: ({ category, ...props }) => (
+                          <div
+                            className="px-3 pt-3 pb-1.5 font-medium text-label-secondary text-xs"
+                            {...props}
+                          >
+                            {category.label}
+                          </div>
+                        ),
+                        Row: ({ children, ...props }) => (
+                          <div
+                            className="grid! scroll-my-1.5 grid-cols-9 gap-0.5 px-1.5"
+                            {...props}
+                          >
+                            {children}
+                          </div>
+                        ),
+                        Emoji: ({ emoji, ...props }) => (
+                          <button
+                            className="flex aspect-square w-full items-center justify-center rounded-md text-2xl hover:bg-fill-secondary data-active:bg-fill-secondary"
+                            {...props}
+                          >
+                            {emoji.emoji}
+                          </button>
+                        ),
+                      }}
+                    />
+                    <Spacer className="h-4" />
+                  </EmojiPicker.Viewport>
+
+                  <Spacer className="h-4" />
+                </EmojiPicker.Root>
+              )
+            }}
+          />
+        </Drawer.Content>
+      </Drawer.NestedRoot>
+    </>
+  )
+}

--- a/src/app/settings/categories/_comps/CategoryList.tsx
+++ b/src/app/settings/categories/_comps/CategoryList.tsx
@@ -1,0 +1,53 @@
+import type { Doc } from "#/convex/_generated/dataModel"
+import { Emoji } from "@/components/ui/emoji"
+import { InsetList } from "@/components/ui/inset-list"
+import { CategoryActionsMenu } from "./CategoryActionsMenu"
+
+export function CategoryList({
+  categories,
+}: {
+  categories: Doc<"categories">[]
+}) {
+  return (
+    <InsetList.Root>
+      <InsetList.Section>
+        <InsetList.SectionHeader visuallyHidden>
+          <InsetList.SectionTitle>Categories</InsetList.SectionTitle>
+        </InsetList.SectionHeader>
+        {categories.map((category) => (
+          <CategoryListItem category={category} key={category._id} />
+        ))}
+      </InsetList.Section>
+    </InsetList.Root>
+  )
+}
+
+const CategoryListItem = ({ category }: { category: Doc<"categories"> }) => {
+  const { icon, color, name } = category
+  return (
+    <InsetList.Item
+      style={
+        {
+          "--item-color":
+            color === "gray" ? "var(--gray-1)" : `var(--ios-${color})`,
+        } as React.CSSProperties
+      }
+    >
+      <InsetList.ItemLeading className="gap-4">
+        <span className="size-3 rounded-full bg-(--item-color)/(--fill-secondary-opacity) outline-(--item-color) outline-2" />
+        <InsetList.ItemMedia aria-hidden="true" variant="symbol">
+          <Emoji className="text-lg">{icon}</Emoji>
+        </InsetList.ItemMedia>
+      </InsetList.ItemLeading>
+
+      <InsetList.ItemContent>
+        <InsetList.ItemBody>
+          <InsetList.ItemTitle>{name}</InsetList.ItemTitle>
+        </InsetList.ItemBody>
+        <InsetList.ItemTrailing>
+          <CategoryActionsMenu category={category} />
+        </InsetList.ItemTrailing>
+      </InsetList.ItemContent>
+    </InsetList.Item>
+  )
+}

--- a/src/app/settings/categories/_comps/CategoryListSection.tsx
+++ b/src/app/settings/categories/_comps/CategoryListSection.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { useQuery } from "convex-helpers/react/cache"
+import { api } from "#/convex/_generated/api"
+import type { TransactionTypes } from "#lib/constants/transaction-types"
+import { Spinner } from "@/components/loading/spinner"
+import { useQueryParamTabSelection } from "@/components/navigation/query-param-tabs/hooks"
+import { CategoryList } from "./CategoryList"
+import { CATEGORY_TYPE_TAB_ITEMS } from "./CategoryToolbar"
+
+export default function CategoryListSection() {
+  /** @todo: properly type useQueryParamTabSelection to infer from its items arg */
+  const selectedType = useQueryParamTabSelection(
+    "type",
+    CATEGORY_TYPE_TAB_ITEMS
+  ) as TransactionTypes | undefined
+  const categories = useQuery(
+    api.category.listByType,
+    selectedType ? { type: selectedType } : "skip"
+  )
+  const isLoading = categories === undefined
+
+  if (isLoading) return <Spinner />
+
+  return <CategoryList categories={categories} />
+}

--- a/src/app/settings/categories/_comps/CategoryToolbar.tsx
+++ b/src/app/settings/categories/_comps/CategoryToolbar.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { MdAdd } from "react-icons/md"
+import { Container } from "@/components/layout/container"
+import {
+  type QueryParamTabItem,
+  QueryParamTabs,
+} from "@/components/navigation/query-param-tabs"
+import { useQueryParamTabSelection } from "@/components/navigation/query-param-tabs/hooks"
+import { Button } from "@/components/ui/button"
+
+export const CATEGORY_TYPE_TAB_ITEMS = [
+  { id: "expense", label: "Expense", value: null },
+  { id: "income", label: "Income", value: "income" },
+] satisfies QueryParamTabItem[]
+
+export function CategoryToolbar() {
+  const selectedKey = useQueryParamTabSelection("type", CATEGORY_TYPE_TAB_ITEMS)
+
+  return (
+    <div className="pointer-events-none absolute top-4 left-1/2 w-full -translate-x-1/2 px-4 [&_a]:pointer-events-auto [&_button]:pointer-events-auto">
+      <Container className="relative">
+        <QueryParamTabs
+          aria-label="Category Filter"
+          items={CATEGORY_TYPE_TAB_ITEMS}
+          param="type"
+          selectedKey={selectedKey}
+          tabListClassName="max-w-50"
+        />
+        {/* TODO: show button when category creation api is up */}
+        <Button
+          className="absolute top-1/2 right-0 hidden -translate-y-1/2 font-normal"
+          color="gray"
+          isDisabled
+          isIconOnly
+        >
+          <MdAdd size={24} />
+        </Button>
+      </Container>
+    </div>
+  )
+}

--- a/src/app/settings/categories/page.tsx
+++ b/src/app/settings/categories/page.tsx
@@ -1,20 +1,28 @@
-"use client"
-
+import { Suspense } from "react"
 import { Container } from "@/components/layout/container"
-import { Header } from "@/components/ui/navigation-header/header"
-import { Spacer } from "@/components/ui/spacer"
-
-import { Categories } from "../local-comps/Categories"
+import { Spinner } from "@/components/loading/spinner"
+import { PageHeader } from "@/components/navigation/page-header"
+import CategoryListSection from "./_comps/CategoryListSection"
+import { CategoryToolbar } from "./_comps/CategoryToolbar"
 
 export default function Page() {
   return (
-    <main className="flex-1 px-4" data-vaul-drawer-wrapper="">
-      <Spacer className="h-4" />
-      <Container as="section" className="flex flex-col gap-0.5">
-        <Header href="/settings" title="Categories" />
-        <Spacer className="h-8" />
-        <Categories />
-      </Container>
-    </main>
+    <>
+      <PageHeader
+        backHref="/settings"
+        margin={9}
+        title="Category Settings"
+        visuallyHidden
+      />
+
+      <main className="flex-1 px-4" data-vaul-drawer-wrapper="">
+        <Container as="section" className="flex flex-col">
+          <Suspense fallback={<Spinner />}>
+            <CategoryToolbar />
+            <CategoryListSection />
+          </Suspense>
+        </Container>
+      </main>
+    </>
   )
 }

--- a/src/app/settings/local-comps/Categories.tsx
+++ b/src/app/settings/local-comps/Categories.tsx
@@ -28,6 +28,11 @@ import {
 } from "@/lib/schema/categories"
 import { cn, sanitizeName } from "@/lib/utils"
 
+/**
+ * @deprecated Use the categories settings components under
+ * `src/app/settings/categories/_comps` instead. This legacy component is kept
+ * temporarily for compatibility and will be removed.
+ */
 export function Categories() {
   const categories = useQuery(api.category.list)
 


### PR DESCRIPTION
## Overview

Replaces the legacy categories settings view with a dedicated category management UI on the existing `settings/categories` route.

## Changes

- Swap out the deprecated `Categories` component from `settings/categories/page.tsx`
- Add `PageHeader`, a query-param-driven type filter toolbar, and a filtered list section
- Render categories from `api.category.listByType` with per-category actions (edit, delete)
- Hide delete affordance for built-in/vendor categories
- Add button for category creation is hidden pending the creation API (shipping next week)

## Notes

- No new route added
- Legacy `Categories` component file is not removed, only de-referenced here
- Category creation is not part of this PR