### PR TITLE
Remove unimplemented Edit button from transaction details drawer

### DIFF
--- a/src/app/activity/_comp/Drawer.tsx
+++ b/src/app/activity/_comp/Drawer.tsx
@@ -4,7 +4,6 @@ import { format } from "date-fns"
 import { Drawer } from "vaul"
 import { api } from "#/convex/_generated/api"
 import { DataTable, type DataType } from "@/app/(index)/local-comps/DataTable"
-import { Button as AnimatedButton } from "@/components/ui/button/animated-button"
 import { ConfirmButton } from "@/components/ui/confirm-button"
 import { useCurrencyFormatter } from "@/hooks/useCurrencyFormatter"
 import { cn } from "@/lib/utils"
@@ -74,10 +73,7 @@ function Comp({
             data={data}
           />
 
-          <div className="flex flex-row-reverse gap-2">
-            <AnimatedButton className="flex-1" color="gray" isDisabled>
-              Edit
-            </AnimatedButton>
+          <div className="mt-4 flex">
             <ConfirmButton
               className="flex-1"
               onConfirm={() => {


### PR DESCRIPTION
## Overview

Removes the stale "Edit" button from the transaction details drawer on the Activity page. Transaction editing is not yet implemented, so the button served no purpose.

## Notes

Edit transaction flow is being planned and will be implemented in a future update.