### PR TITLE
Prevent horizontal scroll when visuallyHidden is applied

### DIFF
--- a/src/components/ui/inset-list.tsx
+++ b/src/components/ui/inset-list.tsx
@@ -146,8 +146,8 @@ const SectionHeader = ({
   return (
     <Comp
       className={cn(
-        "InsetListSectionHeader w-full px-4 pt-6 pb-1.5",
-        visuallyHidden && "sr-only",
+        "InsetListSectionHeader",
+        visuallyHidden ? "sr-only" : "w-full px-4 pt-6 pb-1.5",
         className
       )}
       {...rest}


### PR DESCRIPTION
## Overview

`SectionHeader` was applying layout classes (`w-full px-4 pt-6 pb-1.5`) alongside `sr-only` when `visuallyHidden` was true. Since `sr-only` doesn't fully suppress layout participation in all cases, this caused a horizontal scroll artifact.

## Changes

- Made layout classes and `sr-only` mutually exclusive in `SectionHeader`'s `cn()` call