### PR TITLE
Rename "Auto" to "System" in theme switcher

### DIFF
--- a/src/app/settings/appearance/page.tsx
+++ b/src/app/settings/appearance/page.tsx
@@ -10,7 +10,7 @@ import { Spacer } from "@/components/ui/spacer"
 import { cn } from "@/lib/utils"
 
 const THEME_OPTIONS = [
-  { label: "Auto", value: "system" },
+  { label: "System", value: "system" },
   { label: "Dark", value: "dark" },
   { label: "Light", value: "light" },
 ] as const


### PR DESCRIPTION
Changes the theme switcher label from "Auto" to "System" to better reflect that the option follows the OS-level theme preference. "System" is the standard term used across major platforms and design systems.