### PR TITLE
Improve accessibility and semantic markup for emojis

### DIFF
--- a/src/app/activity/_comp/TransactionList.tsx
+++ b/src/app/activity/_comp/TransactionList.tsx
@@ -119,10 +119,7 @@ function Item(props: {
       )}
       onPress={onPress}
     >
-      <Emoji
-        aria-hidden={true}
-        className="mr-3 transition-scale duration-130 group-data-pressed/ListItem:scale-85"
-      >
+      <Emoji className="mr-3 transition-scale duration-130 group-data-pressed/ListItem:scale-85">
         {txn.category.icon}
       </Emoji>
       <div className="relative flex h-full flex-1 items-center">

--- a/src/components/transaction/new-form/fields/account-field.tsx
+++ b/src/components/transaction/new-form/fields/account-field.tsx
@@ -67,10 +67,7 @@ export function AccountField({
                   id={acc._id}
                   isDisabled={!acc.is_active}
                 >
-                  <Emoji
-                    aria-hidden={true}
-                    className="mr-3 flex items-center gap-3"
-                  >
+                  <Emoji className="mr-3 flex items-center gap-3">
                     {acc.icon}
                   </Emoji>
                   <span className="font-medium">{acc.name}</span>

--- a/src/components/transaction/new-form/fields/category-field.tsx
+++ b/src/components/transaction/new-form/fields/category-field.tsx
@@ -66,7 +66,6 @@ export function CategoryField({
                   id={cat._id}
                 >
                   <Emoji
-                    aria-hidden={true}
                     className={cn(
                       "mr-3 flex items-center gap-3"
                       // Color swatch before the icon

--- a/src/components/ui/emoji.tsx
+++ b/src/components/ui/emoji.tsx
@@ -3,8 +3,23 @@ import type { ComponentProps } from "react"
 
 import { cn } from "@/lib/utils"
 
-export function Emoji({ className, ...rest }: ComponentProps<typeof ark.p>) {
+export function Emoji({
+  className,
+  "aria-label": ariaLabel,
+  "aria-hidden": ariaHidden,
+  ...rest
+}: ComponentProps<typeof ark.span>) {
   return (
-    <ark.p className={cn("font-rnx-rounded text-white", className)} {...rest} />
+    <ark.span
+      aria-hidden={ariaHidden ?? (ariaLabel ? undefined : true)}
+      aria-label={ariaLabel}
+      className={cn(
+        "ui-emoji",
+        "select-none font-rnx-rounded text-white leading-none tracking-[0]",
+        className
+      )}
+      data-ui="emoji"
+      {...rest}
+    />
   )
 }


### PR DESCRIPTION
- Change from paragraph to span element for better semantics
- Add aria-label and aria-hidden support for screen readers
- Default to hiding emoji from assistive tech unless explicitly labeled
- Prevent emoji from being selectable