### PR TITLE
Extract repeated interaction style overrides into a shared no-drag utility

### DIFF
--- a/src/app/settings/local-comps/Accounts.tsx
+++ b/src/app/settings/local-comps/Accounts.tsx
@@ -64,15 +64,8 @@ function AccountItems(props: { account: Doc<"accounts">; isDefault: boolean }) {
   return (
     <List.Item asChild>
       <Link
-        className="cursor-auto data-pressed:bg-fill-tertiary"
+        className="no-drag data-pressed:bg-fill-tertiary"
         href={`/settings/accounts/${slug}`}
-        style={
-          {
-            WebkitUserDrag: "none",
-            userDrag: "none",
-            WebkitTouchCallout: "none",
-          } as CSSProperties
-        }
       >
         <List.Image>
           <Emoji className="text-xl">{account.icon}</Emoji>

--- a/src/app/settings/local-comps/SettingsOptions.tsx
+++ b/src/app/settings/local-comps/SettingsOptions.tsx
@@ -23,17 +23,6 @@ type AnchorListBoxItemRenderProps = Extract<
   { href?: unknown }
 >
 
-const LIST_BOX_ITEM_STYLE = {
-  WebkitUserDrag: "none",
-  userDrag: "none",
-  WebkitTouchCallout: "none",
-  cursor: "default",
-  userSelect: "none",
-  msUserSelect: "none",
-  WebkitUserSelect: "none",
-  MozUserSelect: "none",
-} as React.CSSProperties
-
 function isAnchorRenderProps(
   props: ListBoxItemRenderProps
 ): props is AnchorListBoxItemRenderProps & { href: string } {
@@ -102,6 +91,7 @@ function renderInsetListLinkItem({
 
   return (
     <ListBoxItem
+      className="no-drag"
       href={href}
       id={id}
       render={(domProps) => {
@@ -115,7 +105,6 @@ function renderInsetListLinkItem({
         }
         return <InsetList.Item {...domProps} />
       }}
-      style={LIST_BOX_ITEM_STYLE}
       target={target}
       textValue={textValue}
     >
@@ -205,6 +194,7 @@ function renderSettingsItem(option: SettingsOption) {
             target: option.external ? "_blank" : "_self",
           }
         : {})}
+      className="no-drag"
       render={(domProps) => {
         if (isAnchorRenderProps(domProps)) {
           const { href: linkHref, ...linkProps } = domProps
@@ -216,7 +206,6 @@ function renderSettingsItem(option: SettingsOption) {
         }
         return <InsetList.Item {...domProps} />
       }}
-      style={LIST_BOX_ITEM_STYLE}
       textValue={option.label}
     >
       <InsetList.ItemLeading>

--- a/src/components/app/header/SettingsButton.tsx
+++ b/src/components/app/header/SettingsButton.tsx
@@ -17,26 +17,10 @@ export function SettingsButton() {
   if (!(isMounted && isLoaded && isSignedIn && user)) return null
 
   return (
-    <Link
-      className="size-8"
-      href="/settings"
-      style={
-        // TODO: extract these options to somewhere reasonable
-        {
-          WebkitUserDrag: "none",
-          userDrag: "none",
-          WebkitTouchCallout: "none",
-          cursor: "default",
-          userSelect: "none",
-          msUserSelect: "none",
-          WebkitUserSelect: "none",
-          MozUserSelect: "none",
-        } as React.CSSProperties
-      }
-    >
+    <Link className="no-drag **:no-drag size-8" href="/settings">
       <Avatar.Root
         aria-hidden="true"
-        className="inline-flex size-8 select-none items-center justify-center overflow-hidden rounded-full bg-background-primary-elevated align-middle font-normal text-label-secondary text-sm leading-none"
+        className="inline-flex size-8 items-center justify-center overflow-hidden rounded-full bg-background-primary-elevated align-middle font-normal text-label-secondary text-sm leading-none"
       >
         <Avatar.Image
           className="size-full object-cover"

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -36,21 +36,9 @@ function Item({
       className={buttonVariants({
         variant: "ghost",
         className:
-          "h-12.5 cursor-default select-none flex-col items-center justify-center gap-2.25 font-semibold text-[0.625rem] text-label-primary sm:h-12.5 sm:w-20 sm:text-[0.625rem]",
+          "no-drag h-12.5 flex-col items-center justify-center gap-2.25 font-semibold text-[0.625rem] text-label-primary sm:h-12.5 sm:w-20 sm:text-[0.625rem]",
       })}
       href={href}
-      style={
-        {
-          WebkitUserDrag: "none",
-          userDrag: "none",
-          WebkitTouchCallout: "none",
-          cursor: "default",
-          userSelect: "none",
-          msUserSelect: "none",
-          WebkitUserSelect: "none",
-          MozUserSelect: "none",
-        } as React.CSSProperties
-      }
     >
       <span
         aria-hidden={true}

--- a/src/components/navigation/query-param-tabs/index.tsx
+++ b/src/components/navigation/query-param-tabs/index.tsx
@@ -57,7 +57,7 @@ export function QueryParamTabs({
           return (
             <Tab
               className={cn(
-                "react-aria-Tab relative inline-grid h-full w-full cursor-default touch-none select-none place-content-center rounded-full font-medium text-label-primary text-sm focus:outline-none focus-visible:outline-none",
+                "react-aria-Tab no-drag relative inline-grid h-full w-full place-content-center rounded-full font-medium text-label-primary text-sm focus:outline-none focus-visible:outline-none",
                 "outline-ios-blue data-focus-visible:z-1 data-focus-visible:outline-3",
                 "data-selected:font-semibold",
                 // --- separator ---
@@ -74,13 +74,6 @@ export function QueryParamTabs({
                 ) : (
                   <div {...domProps} />
                 )
-              }
-              style={
-                {
-                  WebkitUserDrag: "none",
-                  userDrag: "none",
-                  WebkitTouchCallout: "none",
-                } as React.CSSProperties
               }
             >
               {({ isSelected }) => (

--- a/src/css/utils.css
+++ b/src/css/utils.css
@@ -1,3 +1,10 @@
 @utility corner-squircle {
   corner-shape: squircle;
 }
+
+@utility no-drag {
+  -webkit-user-drag: none;
+  -webkit-touch-callout: none;
+  cursor: default;
+  user-select: none;
+}


### PR DESCRIPTION
## Overview

Consolidates repeated inline style objects across interactive components into a single reusable `no-drag` Tailwind utility.

## Changes

- Added `@utility no-drag` to `utils.css` with `-webkit-user-drag`, `-webkit-touch-callout`, `cursor: default`, and `user-select: none`
- Replaced all `style={...}` inline drag/select overrides in `SettingsButton`, `Navigation`, `QueryParamTabs`, `SettingsOptions`, and `Accounts` with `className="no-drag"`
- Removed `LIST_BOX_ITEM_STYLE` constant from `SettingsOptions.tsx`