### PR TITLE
Correct typo and selector syntax in separator component

### DIFF
--- a/src/components/app/summary/FlowSummary.tsx
+++ b/src/components/app/summary/FlowSummary.tsx
@@ -124,7 +124,7 @@ const Summary = ({
         </p>
       </div>
 
-      <Separator className="mt-3 mb-4" noMargin useBlendig />
+      <Separator className="mt-3 mb-4" noMargin useBlending />
 
       <div className="grid grid-cols-3 md:grid-cols-5">
         {metrics.map((item) => {

--- a/src/components/ui/list-v2.tsx
+++ b/src/components/ui/list-v2.tsx
@@ -31,7 +31,7 @@ function Item({ className, ...rest }: ComponentProps<typeof ark.div>) {
     <ark.div
       className={cn(
         "ListItem",
-        "group/item flex h-13 w-full gap-1 bg-fill-opaque px-4 first:rounded-t-[1.625rem] last:rounded-b-[1.625rem] first:[&_[role='separator']]:bg-fill-opaque",
+        "group/item flex h-13 w-full gap-1 bg-fill-opaque px-4 first:rounded-t-[1.625rem] last:rounded-b-[1.625rem] first:**:[[role='separator']]:bg-fill-opaque",
         className
       )}
       {...rest}
@@ -71,7 +71,7 @@ function Content({
       className={cn("ListContent", "flex h-full w-full flex-col", className)}
       {...rest}
     >
-      <Separator noMargin orientation="horizontal" useBlendig />
+      <Separator noMargin orientation="horizontal" useBlending />
       {children}
     </ark.div>
   )

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -11,7 +11,7 @@ export interface SeparatorProps extends SeparatorPrimitiveProps {
   className?: string
   opacity?: "opaque" | "non-opaque"
   noMargin?: boolean
-  useBlendig?: boolean
+  useBlending?: boolean
 }
 
 function Separator({
@@ -19,7 +19,7 @@ function Separator({
   opacity = "opaque",
   orientation,
   noMargin = false,
-  useBlendig = false,
+  useBlending = false,
   ...rest
 }: SeparatorProps) {
   const { separatorProps } = useSeparator(rest)
@@ -34,9 +34,9 @@ function Separator({
         orientation === "vertical"
           ? "mx-1.5 h-full w-px"
           : "my-1.5 h-px w-full",
-        useBlendig && [
+        useBlending && [
           // "bg-separator-opaque mix-blend-screen dark:mix-blend-color-dodge",
-          "bg-black/12 mix-blend-plus-darker dark:bg-[#1A1A1A]/100 dark:mix-blend-screen",
+          "bg-black/12 mix-blend-plus-darker dark:bg-[#1A1A1A] dark:mix-blend-screen",
         ],
         noMargin && "m-0",
         className


### PR DESCRIPTION
- Rename useBlendig prop to useBlending for separator and callsites
- Fix CSS selector syntax in list item styles
- Adjust dark mode background opacity value for better blending