### PR TITLE
Disable editor auto-fix for unused imports

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -43,6 +43,12 @@
     "enabled": true,
     "rules": {
       "recommended": true,
+      "correctness": {
+        "noUnusedImports": {
+          "level": "error",
+          "fix": "none"
+        }
+      },
       "suspicious": {
         "noUnknownAtRules": "off",
         "noConsole": {


### PR DESCRIPTION
## Overview

Biome's unused import rule is now enforced at error level with auto-fix disabled.

## Why

Auto-fix was removing imports whenever they were temporarily commented out — say, while debugging. Go to uncomment the code, and the import is already gone. Had to re-import things multiple times a day. Turning off auto-fix keeps the error visible so you know what to clean up, without the editor deciding for you.

## Notes

Unused imports now fail `bun check` and CI. Run `bun check` or `bun fix` before pushing to catch any pre-existing violations.