### PR TITLE
Fix low-contrast delete button on activity drawer

### DIFF
--- a/src/app/activity/_comp/Drawer.tsx
+++ b/src/app/activity/_comp/Drawer.tsx
@@ -80,7 +80,7 @@ function Comp({
                 onOpenChange(false)
                 removeTransaction({ id: txn._id })
               }}
-              restVariants={{ color: "gray" }}
+              restVariants={{ color: "red" }}
             />
           </div>
         </Drawer.Content>


### PR DESCRIPTION
**Overview**

The delete button was using `gray` as its color variant, making it appear visually disabled. Changed to `red` to communicate destructive intent and restore contrast.

**Changes**

- `Drawer.tsx`: `restVariants.color` changed from `"gray"` to `"red"`