### PR TITLE
Polish avatar styling across profile header, settings list, and nav button

### DIFF
--- a/src/app/settings/local-comps/SettingsOptions.tsx
+++ b/src/app/settings/local-comps/SettingsOptions.tsx
@@ -12,12 +12,14 @@ import {
 } from "react-aria-components"
 import { InsetList } from "@/components/ui/inset-list"
 import { Skeleton } from "@/components/ui/loading/skeleton"
-import { getInitials } from "@/components/user/helpers"
+import {
+  AVATAR_FALLBACK_DELAY_MS,
+  getInitials,
+} from "@/components/user/helpers"
 import { cn } from "@/lib/utils"
 import { type SettingsOption, settingsConfig } from "./config"
 
 const AVATAR_IMAGE_SIZE = 60
-const AVATAR_FALLBACK_DELAY_MS = 600
 
 type ListBoxItemRenderProps = Parameters<
   NonNullable<React.ComponentProps<typeof ListBoxItem>["render"]>

--- a/src/app/settings/local-comps/SettingsOptions.tsx
+++ b/src/app/settings/local-comps/SettingsOptions.tsx
@@ -13,7 +13,11 @@ import {
 import { InsetList } from "@/components/ui/inset-list"
 import { Skeleton } from "@/components/ui/loading/skeleton"
 import { getInitials } from "@/components/user/helpers"
+import { cn } from "@/lib/utils"
 import { type SettingsOption, settingsConfig } from "./config"
+
+const AVATAR_IMAGE_SIZE = 60
+const AVATAR_FALLBACK_DELAY_MS = 600
 
 type ListBoxItemRenderProps = Parameters<
   NonNullable<React.ComponentProps<typeof ListBoxItem>["render"]>
@@ -142,15 +146,27 @@ function renderProfileItem({
                 className="size-full rounded-full bg-fill-primary"
               />
             ) : (
-              <Avatar.Root className="grid size-full place-items-center overflow-hidden rounded-full bg-ios-purple font-semibold text-white text-xs">
+              <Avatar.Root
+                className={cn(
+                  "relative grid size-full place-items-center overflow-hidden rounded-full bg-background-primary-elevated font-semibold text-white text-xs",
+
+                  // outline ring for readability
+                  "after:absolute after:inset-0 after:rounded-full after:ring-2 after:ring-separator-opaque/15 after:ring-inset after:content-['']"
+                )}
+              >
                 <Avatar.Image
                   alt="User avatar"
                   className="size-full object-cover"
-                  height={60}
+                  height={AVATAR_IMAGE_SIZE}
                   src={imageUrl}
-                  width={60}
+                  width={AVATAR_IMAGE_SIZE}
                 />
-                <Avatar.Fallback>{getInitials(fullName)}</Avatar.Fallback>
+                <Avatar.Fallback
+                  className="flex size-full items-center justify-center text-label-secondary text-lg"
+                  delay={AVATAR_FALLBACK_DELAY_MS}
+                >
+                  {getInitials(fullName)}
+                </Avatar.Fallback>
               </Avatar.Root>
             )}
           </InsetList.ItemMedia>

--- a/src/app/settings/profile/_comp/ProfileHeader.tsx
+++ b/src/app/settings/profile/_comp/ProfileHeader.tsx
@@ -1,8 +1,8 @@
 import { Avatar } from "@base-ui/react/avatar"
+import { AVATAR_FALLBACK_DELAY_MS } from "@/components/user/helpers"
 import { cn } from "@/lib/utils"
 
 const AVATAR_IMAGE_SIZE = 104
-const AVATAR_FALLBACK_DELAY_MS = 600
 
 export function ProfileHeader({
   displayName,

--- a/src/app/settings/profile/_comp/ProfileHeader.tsx
+++ b/src/app/settings/profile/_comp/ProfileHeader.tsx
@@ -1,7 +1,7 @@
 import { Avatar } from "@base-ui/react/avatar"
 import { cn } from "@/lib/utils"
 
-const PROFILE_IMAGE_SIZE = 104
+const AVATAR_IMAGE_SIZE = 104
 const AVATAR_FALLBACK_DELAY_MS = 600
 
 export function ProfileHeader({
@@ -31,19 +31,23 @@ export function ProfileHeader({
       <div className="relative flex flex-col items-center text-center">
         <Avatar.Root
           className={cn(
-            "relative mb-4 inline-flex size-26 items-center justify-center overflow-hidden bg-[color-mix(in_oklab,var(--ios-blue)_16%,var(--fill-tertiary))] align-middle font-semibold text-3xl text-label-primary leading-none ring-1 ring-black/5 backdrop-blur-sm",
-            "supports-[corner-shape:squircle]:corner-squircle rounded-3xl supports-[corner-shape:squircle]:rounded-[3rem]"
+            "relative mb-4 inline-flex size-26 items-center justify-center overflow-hidden bg-background-primary-elevated align-middle font-semibold text-3xl text-label-primary leading-none shadow-md ring-1 ring-black/5 backdrop-blur-sm",
+            "supports-[corner-shape:squircle]:corner-squircle rounded-3xl supports-[corner-shape:squircle]:rounded-[3rem]",
+
+            // outline ring for readability
+            "after:absolute after:inset-0 after:mix-blend-overlay after:ring-2 after:ring-white/20 after:ring-inset after:content-['']",
+            "supports-[corner-shape:squircle]:after:corner-squircle after:rounded-3xl supports-[corner-shape:squircle]:after:rounded-[3rem]"
           )}
         >
           <Avatar.Image
             alt={`${displayName} profile photo`}
             className="size-full object-cover"
-            height={PROFILE_IMAGE_SIZE}
+            height={AVATAR_IMAGE_SIZE}
             src={imageUrl}
-            width={PROFILE_IMAGE_SIZE}
+            width={AVATAR_IMAGE_SIZE}
           />
           <Avatar.Fallback
-            className="flex size-full items-center justify-center"
+            className="flex size-full items-center justify-center text-label-secondary"
             delay={AVATAR_FALLBACK_DELAY_MS}
           >
             {initials}

--- a/src/components/app/header/SettingsButton.tsx
+++ b/src/components/app/header/SettingsButton.tsx
@@ -4,10 +4,12 @@ import { Avatar } from "@base-ui/react/avatar"
 import { useUser } from "@clerk/nextjs"
 import Link from "next/link"
 import { useEffect, useState } from "react"
-import { getInitials } from "@/components/user/helpers"
+import {
+  AVATAR_FALLBACK_DELAY_MS,
+  getInitials,
+} from "@/components/user/helpers"
 
 const AVATAR_IMAGE_SIZE = 32
-const AVATAR_FALLBACK_DELAY_MS = 600
 
 export function SettingsButton() {
   const [isMounted, setIsMounted] = useState(false)

--- a/src/components/app/header/SettingsButton.tsx
+++ b/src/components/app/header/SettingsButton.tsx
@@ -6,6 +6,9 @@ import Link from "next/link"
 import { useEffect, useState } from "react"
 import { getInitials } from "@/components/user/helpers"
 
+const AVATAR_IMAGE_SIZE = 32
+const AVATAR_FALLBACK_DELAY_MS = 600
+
 export function SettingsButton() {
   const [isMounted, setIsMounted] = useState(false)
   const { user, isSignedIn, isLoaded } = useUser()
@@ -20,17 +23,17 @@ export function SettingsButton() {
     <Link className="no-drag **:no-drag size-8" href="/settings">
       <Avatar.Root
         aria-hidden="true"
-        className="inline-flex size-8 items-center justify-center overflow-hidden rounded-full bg-background-primary-elevated align-middle font-normal text-label-secondary text-sm leading-none"
+        className="inline-flex size-8 items-center justify-center overflow-hidden rounded-full bg-background-primary-elevated align-middle font-normal text-label-secondary text-sm leading-none shadow-ios-md outline-2 outline-white/15"
       >
         <Avatar.Image
           className="size-full object-cover"
-          height="32"
+          height={AVATAR_IMAGE_SIZE}
           src={user.imageUrl}
-          width="32"
+          width={AVATAR_IMAGE_SIZE}
         />
         <Avatar.Fallback
           className="flex size-full items-center justify-center text-sm"
-          delay={600}
+          delay={AVATAR_FALLBACK_DELAY_MS}
         >
           {getInitials(user.fullName)}
         </Avatar.Fallback>

--- a/src/components/user/helpers.ts
+++ b/src/components/user/helpers.ts
@@ -10,3 +10,5 @@ export const getInitials = (fullName: string | null | undefined) => {
     .join("")
     .toUpperCase()
 }
+
+export const AVATAR_FALLBACK_DELAY_MS = 600


### PR DESCRIPTION
## Overview

Follow-up to #84. Refines avatar appearance in three locations: profile header, settings options list, and the nav bar settings button.

## Changes

- **Profile header** — swaps tinted blue background for `bg-background-primary-elevated`, adds `shadow-md`, and applies an inset overlay ring (with squircle-aware `after:` pseudo-element) for readability
- **Settings options list** — same background swap from `bg-ios-purple`; adds inset `ring-separator-opaque/15` outline; fallback gets explicit size/color classes and the 600ms delay
- **Settings button** — adds `shadow-ios-md` and `outline-white/15`; extracts magic numbers (`32`, `600`) into named constants

## Notes

Depends on #84. Assumes `Avatar.Root/Image/Fallback` are already in place from that PR.