### PR TITLE
Add transaction type icon component

### DIFF
--- a/src/components/icons/TransactionTypeIcon.tsx
+++ b/src/components/icons/TransactionTypeIcon.tsx
@@ -1,0 +1,26 @@
+import type { IconBaseProps, IconType } from "react-icons/lib"
+import { MdArrowDownward, MdArrowUpward } from "react-icons/md"
+import type { TransactionTypes } from "#lib/constants/transaction-types"
+
+/** Maps each transaction type to its corresponding icon component. */
+export const iconMap = {
+  expense: MdArrowDownward,
+  income: MdArrowUpward,
+} satisfies Record<TransactionTypes, IconType>
+
+export interface TransactionTypeIconProps extends IconBaseProps {
+  type: TransactionTypes
+}
+
+/**
+ * Renders the icon associated with a given transaction type.
+ * Accepts all `IconBaseProps` (size, color, etc.) via spread.
+ */
+export function TransactionTypeIcon({
+  type,
+  ...rest
+}: TransactionTypeIconProps) {
+  const Icon = iconMap[type]
+
+  return <Icon {...rest} />
+}


### PR DESCRIPTION
## Overview

Adds `TransactionTypeIcon`, a reusable component that renders a directional arrow icon based on transaction type (income/expense).

## Changes

- New component at `src/components/icons/TransactionTypeIcon.tsx`
- Exports `iconMap` for direct icon lookup by transaction type
- Accepts all `IconBaseProps` (size, color, className, etc.) via spread