### PR TITLE
Sort color palette by hue wheel order

### DIFF
--- a/lib/constants/colors.ts
+++ b/lib/constants/colors.ts
@@ -1,6 +1,4 @@
 export const colors = [
-  "gray",
-  "blue",
   "red",
   "orange",
   "yellow",
@@ -8,9 +6,11 @@ export const colors = [
   "mint",
   "teal",
   "cyan",
+  "blue",
   "indigo",
   "purple",
   "pink",
   "brown",
+  "gray",
 ] as const
 export type Colors = (typeof colors)[number]


### PR DESCRIPTION
**Summary:**

Reorders the `colors` array to follow the hue wheel (red → orange → yellow → green → mint → teal → cyan → blue → indigo → purple → pink), with neutrals (`brown`, `gray`) at the end.

Any UI that maps over this array (e.g. color pickers) now renders colors in a visually harmonized sequence without extra sorting logic.