### PR TITLE
Add squircle CSS utilities with `@supports` guard

### DIFF
--- a/src/css/utils.css
+++ b/src/css/utils.css
@@ -1,5 +1,20 @@
+/**
+ * @deprecated Use `squircle` instead.
+ */
 @utility corner-squircle {
   corner-shape: squircle;
+}
+
+@utility squircle {
+  @supports (corner-shape: squircle) {
+    corner-shape: squircle;
+  }
+}
+
+@utility squircle-rounded-* {
+  @supports (corner-shape: squircle) {
+    border-radius: --value(--radius-*);
+  }
 }
 
 @utility no-drag {


### PR DESCRIPTION
## Overview

Adds two new Tailwind utilities for squircle corner shapes, guarded behind `@supports (corner-shape: squircle)` so they degrade gracefully in unsupported browsers.

- `squircle` — applies `corner-shape: squircle`
- `squircle-rounded-*` — applies `border-radius` using the standard radius scale

`corner-squircle` is kept for backward compatibility but marked `@deprecated` in favor of `squircle`.