### PR TITLE
Add shared compact number formatting options to lib

### DIFF
--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,0 +1,12 @@
+/**
+ * Format options for compact number display.
+ *
+ * @example
+ * new Intl.NumberFormat("en", compactNumberFormatOptions).format(4500)  // "4.5K"
+ * new Intl.NumberFormat("en", compactNumberFormatOptions).format(2_000_000)  // "2M"
+ */
+export const compactNumberFormatOptions = {
+  notation: "compact",
+  compactDisplay: "short",
+  maximumFractionDigits: 1,
+} as const satisfies Intl.NumberFormatOptions


### PR DESCRIPTION
**Overview**

Adds `compactNumberFormatOptions` to `lib/format.ts` — a shared `Intl.NumberFormatOptions` constant for compact number display (e.g. `4500 → "4.5K"`, `2_000_000 → "2M"`). Centralizes format config previously duplicated or inlined across call sites.

**Changes**

- New file `lib/format.ts` exporting `compactNumberFormatOptions` typed as `const satisfies Intl.NumberFormatOptions`

**Notes**

- Framework-agnostic; lives in `lib/` per project convention, aliased as `#lib/format`
- `maximumFractionDigits: 1` keeps output concise without losing precision for typical finance display ranges