### PR TITLE
Add utility to map color tokens to CSS custom properties

### DIFF
--- a/lib/utils/colors.ts
+++ b/lib/utils/colors.ts
@@ -1,0 +1,18 @@
+import type { Colors } from "#lib/constants/colors"
+
+export type ColorCSSVar =
+  | "var(--gray-1)"
+  | `var(--ios-${Exclude<Colors, "gray">})`
+
+/**
+ * Maps a {@link Colors} token to its CSS custom property reference.
+ *
+ * @example
+ * // In a style prop:
+ * { "--item-color": colorToCSSVar(color) }
+ * // In Tailwind:
+ * "bg-(--item-color)"
+ */
+export function colorToCSSVar(color: Colors): ColorCSSVar {
+  return color === "gray" ? "var(--gray-1)" : `var(--ios-${color})`
+}


### PR DESCRIPTION
**Overview**

Adds `colorToCSSVar` — a typed mapper from `Colors` tokens to their CSS variable references — and `ColorCSSVar`, the union type representing valid return values.

**Changes**

- `ColorCSSVar`: union type narrowing the return to `"var(--gray-1)"` or `` `var(--ios-${...})` ``
- `colorToCSSVar(color)`: maps `"gray"` → `var(--gray-1)`, all others → `var(--ios-${color})`

**Usage**

```ts
// style prop
{ "--item-color": colorToCSSVar(color) }

// Tailwind
"bg-(--item-color)"
```